### PR TITLE
0020 exclude macos from volumes list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![Build](https://circleci.com/gh/hashgraph/hedera-transaction-tool-demo.svg?style=shield)](https://app.circleci.com/pipelines/github/hashgraph/hedera-transaction-tool-demo)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=com.hedera.hashgraph%3Ahedera-transaction-tool&metric=alert_status&token=028c36aa276e50cba3e8f765a6e709ae2336443b)](https://sonarcloud.io/dashboard?id=com.hedera.hashgraph%3Ahedera-transaction-tool)
 
 # Hedera Transaction Tool Demo

--- a/tools-core/src/main/java/com/hedera/hashgraph/client/core/fileservices/FileAdapterFactory.java
+++ b/tools-core/src/main/java/com/hedera/hashgraph/client/core/fileservices/FileAdapterFactory.java
@@ -16,23 +16,6 @@
  * limitations under the License.
  */
 
-/*
- * (c) 2016-2020 Swirlds, Inc.
- *
- * This software is the confidential and proprietary information of
- * Swirlds, Inc. ("Confidential Information"). You shall not
- * disclose such Confidential Information and shall use it only in
- * accordance with the terms of the license agreement you entered into
- * with Swirlds.
- *
- * SWIRLDS MAKES NO REPRESENTATIONS OR WARRANTIES ABOUT THE SUITABILITY OF
- * THE SOFTWARE, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
- * TO THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
- * PARTICULAR PURPOSE, OR NON-INFRINGEMENT. SWIRLDS SHALL NOT BE LIABLE FOR
- * ANY DAMAGES SUFFERED BY LICENSEE AS A RESULT OF USING, MODIFYING OR
- * DISTRIBUTING THIS SOFTWARE OR ITS DERIVATIVES.
- */
-
 package com.hedera.hashgraph.client.core.fileservices;
 
 import com.hedera.hashgraph.client.core.exceptions.HederaClientException;
@@ -81,8 +64,12 @@ public class FileAdapterFactory {
 			var roots = volume.listFiles();
 			assert roots != null;
 			logger.debug("Found {} volumes", roots.length);
+			//Scan all volumes (MAC only)
 			if (roots.length > 0) {
 				for (var volumes : roots) {
+					// The volume containing the string "HD" is the default name for the laptop's hard drive
+					// Added MACOS to the ignored volumes list, as rebuilt laptops might use it as the name for the
+					// hard drive (08/03/2021)
 					if (volumes.getName().contains("HD") || volumes.getName().equalsIgnoreCase("MACOS")) {
 						continue;
 					}

--- a/tools-core/src/main/java/com/hedera/hashgraph/client/core/fileservices/FileAdapterFactory.java
+++ b/tools-core/src/main/java/com/hedera/hashgraph/client/core/fileservices/FileAdapterFactory.java
@@ -83,9 +83,10 @@ public class FileAdapterFactory {
 			logger.debug("Found {} volumes", roots.length);
 			if (roots.length > 0) {
 				for (var volumes : roots) {
-					if (!volumes.getName().contains("HD")) {
-						return volumes.getAbsolutePath();
+					if (volumes.getName().contains("HD") || volumes.getName().equalsIgnoreCase("MACOS")) {
+						continue;
 					}
+					return volumes.getAbsolutePath();
 				}
 			}
 		}

--- a/tools-ui/src/main/java/com/hedera/hashgraph/client/ui/Controller.java
+++ b/tools-ui/src/main/java/com/hedera/hashgraph/client/ui/Controller.java
@@ -262,10 +262,14 @@ public class Controller implements Initializable, GenericFileReadWriteAware {
 	}
 
 	private void replacePublicKey() {
+		try {
+			Files.deleteIfExists(Path.of(DEFAULT_STORAGE, Constants.PUBLIC_KEY_LOCATION));
+		} catch (IOException e) {
+			logger.error(e);
+		}
 		InputStream readStream = this.getClass().getClassLoader().getResourceAsStream("gpgPublicKey.asc");
 		final var key = new File(DEFAULT_STORAGE, Constants.PUBLIC_KEY_LOCATION);
 		try (OutputStream outputStream = new FileOutputStream(key)) {
-			Files.deleteIfExists(key.toPath());
 			assert readStream != null;
 			IOUtils.copy(readStream, outputStream);
 		} catch (IOException exception) {

--- a/tools-ui/src/main/java/com/hedera/hashgraph/client/ui/Controller.java
+++ b/tools-ui/src/main/java/com/hedera/hashgraph/client/ui/Controller.java
@@ -261,12 +261,18 @@ public class Controller implements Initializable, GenericFileReadWriteAware {
 		this.drivesChanged = drivesChanged;
 	}
 
+	/**
+	 * This method will run only when the application first starts after update. It will replace the existing gpg key
+	 * with the one provided by the new application. We are always assuming that the key could have changed.
+	 */
 	private void replacePublicKey() {
+		// First delete the old key if it exists.
 		try {
 			Files.deleteIfExists(Path.of(DEFAULT_STORAGE, Constants.PUBLIC_KEY_LOCATION));
 		} catch (IOException e) {
 			logger.error(e);
 		}
+		// Then replace it with the key provided in the app resources.
 		InputStream readStream = this.getClass().getClassLoader().getResourceAsStream("gpgPublicKey.asc");
 		final var key = new File(DEFAULT_STORAGE, Constants.PUBLIC_KEY_LOCATION);
 		try (OutputStream outputStream = new FileOutputStream(key)) {


### PR DESCRIPTION
**Description**:
Since there is no straightforward way to find usb drives, the application scans all volumes and discards all volumes associated with the native OS. In some laptops that have been rebuilt, the denomination for the HD is different, and this caused the application to crash.

Fixes #20 

**Notes for reviewer**:
Logs in the issue
Also addressed an issue where the verification public key was not appropriately copied to the Files directory

**Checklist**

- [x] Documented (Code comments, README, etc.)
