### PR TITLE
Removed all scroll bars from tables

### DIFF
--- a/tools-ui/src/main/java/com/hedera/hashgraph/client/ui/AccountsPaneController.java
+++ b/tools-ui/src/main/java/com/hedera/hashgraph/client/ui/AccountsPaneController.java
@@ -391,7 +391,7 @@ public class AccountsPaneController implements GenericFileReadWriteAware {
 			}
 		});
 
-		balanceColumn.prefWidthProperty().bind(table.widthProperty().divide(10).multiply(4).subtract(24));
+		balanceColumn.prefWidthProperty().bind(table.widthProperty().divide(10).multiply(4));
 		balanceColumn.setStyle("-fx-alignment: TOP-RIGHT; -fx-padding: 10");
 		return balanceColumn;
 	}

--- a/tools-ui/src/main/java/com/hedera/hashgraph/client/ui/CreatePaneController.java
+++ b/tools-ui/src/main/java/com/hedera/hashgraph/client/ui/CreatePaneController.java
@@ -949,8 +949,8 @@ public class CreatePaneController implements GenericFileReadWriteAware {
 		table.getColumns().clear();
 		table.getColumns().addAll(accountColumn, amountColumn);
 
-		accountColumn.prefWidthProperty().bind(table.widthProperty().multiply(0.35));
-		amountColumn.prefWidthProperty().bind(table.widthProperty().multiply(0.61));
+		accountColumn.prefWidthProperty().bind(table.widthProperty().multiply(0.395));
+		amountColumn.prefWidthProperty().bind(table.widthProperty().multiply(0.60));
 
 		accountColumn.setResizable(false);
 		amountColumn.setResizable(false);
@@ -975,7 +975,7 @@ public class CreatePaneController implements GenericFileReadWriteAware {
 		});
 
 		table.prefHeightProperty().bind(
-				table.fixedCellSizeProperty().multiply(Bindings.size(table.getItems()).add(1.1)).add(10));
+				table.fixedCellSizeProperty().multiply(Bindings.size(table.getItems()).add(1.1)));
 		table.minHeightProperty().bind(table.prefHeightProperty());
 		table.maxHeightProperty().bind(table.prefHeightProperty());
 		table.managedProperty().bind(table.visibleProperty());

--- a/tools-ui/src/main/java/com/hedera/hashgraph/client/ui/KeysPaneController.java
+++ b/tools-ui/src/main/java/com/hedera/hashgraph/client/ui/KeysPaneController.java
@@ -411,7 +411,6 @@ public class KeysPaneController implements GenericFileReadWriteAware {
 
 			var linkedAccountsColumn = getLinkedAccountsTableColumn(signingKeysTableView);
 
-
 			signingKeysTableView.getColumns().addAll(iconsColumn, nameColumn, linkedAccountsColumn);
 
 			setSigningKeysRowFactory(signingKeysTableView);
@@ -531,8 +530,7 @@ public class KeysPaneController implements GenericFileReadWriteAware {
 	}
 
 	private String hashAsString(String pemLocation) throws KeyStoreException {
-		return String.valueOf(Ed25519KeyStore.getMnemonicHashCode(
-				pemLocation));
+		return String.valueOf(Ed25519KeyStore.getMnemonicHashCode(pemLocation));
 	}
 
 	/**

--- a/tools-ui/src/main/java/com/hedera/hashgraph/client/ui/utilities/KeysTableRow.java
+++ b/tools-ui/src/main/java/com/hedera/hashgraph/client/ui/utilities/KeysTableRow.java
@@ -20,6 +20,7 @@ package com.hedera.hashgraph.client.ui.utilities;
 
 import javafx.beans.property.SimpleStringProperty;
 
+import java.util.Collections;
 import java.util.List;
 
 public class KeysTableRow {
@@ -129,7 +130,8 @@ public class KeysTableRow {
 	}
 
 	private String getStringAccountList(List<String> accounts) {
-		if (accounts == null || accounts.isEmpty()) {
+		Collections.sort(accounts);
+		if (accounts.isEmpty()) {
 			return "No account found";
 		}
 

--- a/tools-ui/src/main/resources/tools.css
+++ b/tools-ui/src/main/resources/tools.css
@@ -69,3 +69,37 @@
 .root{
 	-fx-font-family: 'Styrene A App Regular';
 }
+
+.table-view *.scroll-bar:vertical *.increment-button,
+.table-view *.scroll-bar:vertical *.decrement-button {
+	-fx-background-color: null;
+	-fx-background-radius: 0;
+	-fx-background-insets: 0;
+	-fx-padding: 0;
+}
+
+.table-view *.scroll-bar:vertical *.increment-arrow,
+.table-view *.scroll-bar:vertical *.decrement-arrow {
+	-fx-background-color: null;
+	-fx-background-radius: 0;
+	-fx-background-insets: 0;
+	-fx-padding: 0;
+	-fx-shape: null;
+}
+
+.table-view *.scroll-bar:horizontal *.increment-button,
+.table-view *.scroll-bar:horizontal *.decrement-button {
+	-fx-background-color: null;
+	-fx-background-radius: 0;
+	-fx-background-insets: 0;
+	-fx-padding: 0;
+}
+
+.table-view *.scroll-bar:horizontal *.increment-arrow,
+.table-view *.scroll-bar:horizontal *.decrement-arrow {
+	-fx-background-color: null;
+	-fx-background-radius: 0;
+	-fx-background-insets: 0;
+	-fx-padding: 0;
+	-fx-shape: null;
+}


### PR DESCRIPTION
Signed-off-by: David Sergio Matusevich <davidmatusevich@swirlds.com>

**Description**:
- Removed all scroll bars from tables and trees.
- Fixed column widths to account to account for the lack of scrollbars
- In the Keys pane, the linked accounts are now ordered alphabetically

**Related issue(s)**:

Fixes #26 
