### PR TITLE
Fixed Precheck exceptions in submitter

### DIFF
--- a/tools-cli/src/main/java/com/hedera/hashgraph/client/cli/helpers/TransactionCallableWorker.java
+++ b/tools-cli/src/main/java/com/hedera/hashgraph/client/cli/helpers/TransactionCallableWorker.java
@@ -42,10 +42,10 @@ import static java.lang.Thread.sleep;
 public class TransactionCallableWorker implements Callable<String>, GenericFileReadWriteAware {
 	private static final Logger logger = LogManager.getLogger(TransactionCallableWorker.class);
 
-	private Transaction<?> tx;
-	private int delay;
-	private String location;
-	private Client client;
+	private final Transaction<?> tx;
+	private final int delay;
+	private final String location;
+	private final Client client;
 
 	public TransactionCallableWorker(Transaction<?> tx, int delay, String location, Client client) {
 		this.tx = tx;
@@ -58,7 +58,7 @@ public class TransactionCallableWorker implements Callable<String>, GenericFileR
 	public String call() throws Exception {
 		assert tx != null;
 		assert tx.getTransactionValidDuration() != null;
-		if (Objects.requireNonNull(Objects.requireNonNull(tx.getTransactionId()).validStart.plusSeconds(
+		if (Objects.requireNonNull(Objects.requireNonNull(Objects.requireNonNull(tx.getTransactionId()).validStart).plusSeconds(
 				tx.getTransactionValidDuration().toSeconds())).isBefore(Instant.now())) {
 			throw new HederaClientRuntimeException("Transaction happens in the past.");
 		}
@@ -67,18 +67,21 @@ public class TransactionCallableWorker implements Callable<String>, GenericFileR
 
 		final var idString = Objects.requireNonNull(tx.getTransactionId()).toString();
 
-		var response = submit(tx);
-		assert response != null;
+		try {
+			var response = submit(tx);
+			assert response != null;
 
-		final var status = response.getReceipt(client).status;
-		logger.info("Worker: Transaction: {}, final status: {}", idString, status);
+			final var status = response.getReceipt(client).status;
+			logger.info("Worker: Transaction: {}, final status: {}", idString, status);
 
-		var storageLocation = storeResponse(response, idString);
-		if (status.equals(Status.SUCCESS)) {
-			return storageLocation;
-		} else {
-			return "";
+			var storageLocation = storeResponse(response, idString);
+			if (status.equals(Status.SUCCESS)) {
+				return storageLocation;
+			}
+		} catch (TimeoutException | PrecheckStatusException | ReceiptStatusException | HederaClientException e) {
+			logger.info("Worker: Transaction: {}, failed with error: {}", idString, e.getMessage());
 		}
+		return "";
 	}
 
 	private void sleepUntilNeeded() throws InterruptedException {

--- a/tools-cli/src/main/java/com/hedera/hashgraph/client/cli/options/SubmitCommand.java
+++ b/tools-cli/src/main/java/com/hedera/hashgraph/client/cli/options/SubmitCommand.java
@@ -117,12 +117,12 @@ public class SubmitCommand implements ToolCommand, GenericFileReadWriteAware {
 
 		List<String> transactionResponses = new ArrayList<>();
 		for (var future : transactionsFutureTasks) {
-			final String response;
+			String response;
 			try {
 				response = (String) future.get();
 			} catch (ExecutionException e) {
 				logger.error(e.getMessage());
-				throw new HederaClientException(e);
+				response = "";
 			}
 			if (!"".equals(response)) {
 				transactionResponses.add(response);


### PR DESCRIPTION
Signed-off-by: David Sergio Matusevich <davidmatusevich@swirlds.com>

**Description**:
If the transaction fails in precheck the SDK throws an exception instead of returning a status. This made the submitter act as if nothing was happening and ultimately hang. 

Added checks for failed precheck and appropriate error logging.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
