### PR TITLE
V0.6.1 patch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 	<groupId>com.hedera.hashgraph</groupId>
 	<artifactId>hedera-transaction-tool</artifactId>
 
-	<version>0.6.0</version>
+	<version>0.6.1</version>
 	<name>Hedera Transaction Tool</name>
 
 	<modules>

--- a/tools-bom/pom.xml
+++ b/tools-bom/pom.xml
@@ -28,7 +28,7 @@
 	<parent>
 		<groupId>com.hedera.hashgraph</groupId>
 		<artifactId>hedera-transaction-tool</artifactId>
-		<version>0.6.0</version>
+		<version>0.6.1</version>
 	</parent>
 
 	<!-- Project Identifier & Type -->

--- a/tools-cli/pom.xml
+++ b/tools-cli/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<artifactId>hedera-transaction-tool</artifactId>
 		<groupId>com.hedera.hashgraph</groupId>
-		<version>0.6.0</version>
+		<version>0.6.1</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -33,7 +33,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>tools-cli</artifactId>
-	<version>0.6.0</version>
+	<version>0.6.1</version>
 	<packaging>jar</packaging>
 
 	<dependencyManagement>
@@ -53,7 +53,7 @@
 		<dependency>
 			<groupId>com.hedera.hashgraph</groupId>
 			<artifactId>tools-core</artifactId>
-			<version>0.6.0</version>
+			<version>0.6.1</version>
 		</dependency>
 
 		<!-- Logging SLF4j + Log4j2 implementation -->

--- a/tools-core/pom.xml
+++ b/tools-core/pom.xml
@@ -25,14 +25,14 @@
 	<parent>
 		<artifactId>hedera-transaction-tool</artifactId>
 		<groupId>com.hedera.hashgraph</groupId>
-		<version>0.6.0</version>
+		<version>0.6.1</version>
 	</parent>
 
 	<!-- Maven Model Version -->
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>tools-core</artifactId>
-	<version>0.6.0</version>
+	<version>0.6.1</version>
 	<packaging>jar</packaging>
 
 	<dependencyManagement>

--- a/tools-core/src/main/java/com/hedera/hashgraph/client/core/constants/Constants.java
+++ b/tools-core/src/main/java/com/hedera/hashgraph/client/core/constants/Constants.java
@@ -164,6 +164,10 @@ public class Constants {
 	public static final int KEY_LENGTH = 256;
 	// endregion
 
+	// regex
+	public static final String FULL_ACCOUNT_CHECKSUM_REGEX = "\\d+.\\d+.\\d+-[a-z]{5}";
+	public static final String FULL_ACCOUNT_REGEX = "^\\d+.\\d+.\\d+$";
+	public static final String NUMBER_REGEX = "^[0-9]+$";
 
 	public static final DoubleProperty FONT_SIZE = new SimpleDoubleProperty(16);
 }

--- a/tools-integration/pom.xml
+++ b/tools-integration/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<artifactId>hedera-transaction-tool</artifactId>
 		<groupId>com.hedera.hashgraph</groupId>
-		<version>0.6.0</version>
+		<version>0.6.1</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 
@@ -46,19 +46,19 @@
 		<dependency>
 			<groupId>com.hedera.hashgraph</groupId>
 			<artifactId>tools-core</artifactId>
-			<version>0.6.0</version>
+			<version>0.6.1</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.hedera.hashgraph</groupId>
 			<artifactId>tools-ui</artifactId>
-			<version>0.6.0</version>
+			<version>0.6.1</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.hedera.hashgraph</groupId>
 			<artifactId>tools-cli</artifactId>
-			<version>0.6.0</version>
+			<version>0.6.1</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/tools-integration/src/test/java/com/hedera/hashgraph/client/integration/TestUtil.java
+++ b/tools-integration/src/test/java/com/hedera/hashgraph/client/integration/TestUtil.java
@@ -212,25 +212,30 @@ public class TestUtil {
 	}
 
 	public static Stage findModalWindow() {
-		// Get a list of windows but ordered from top[0] to bottom[n] ones.
-		// It is needed to get the first found modal window.
-		final var windowFinder = robot.robotContext().getWindowFinder();
-		if (windowFinder == null) {
+		try {
+			// Get a list of windows but ordered from top[0] to bottom[n] ones.
+			// It is needed to get the first found modal window.
+			final var windowFinder = robot.robotContext().getWindowFinder();
+			if (windowFinder == null) {
+				return null;
+			}
+			final List<Window> allWindows = new ArrayList<>(windowFinder.listWindows());
+			if (allWindows.isEmpty()) {
+				return null;
+			}
+
+			Collections.reverse(allWindows);
+
+			return (Stage) allWindows
+					.stream()
+					.filter(window -> window instanceof Stage)
+					.filter(window -> ((Stage) window).getModality() == Modality.APPLICATION_MODAL)
+					.findFirst()
+					.orElse(null);
+		} catch (final Exception e) {
+			logger.error(e.getMessage());
 			return null;
 		}
-		final List<Window> allWindows = new ArrayList<>(windowFinder.listWindows());
-		if (allWindows.isEmpty()) {
-			return null;
-		}
-
-		Collections.reverse(allWindows);
-
-		return (Stage) allWindows
-				.stream()
-				.filter(window -> window instanceof Stage)
-				.filter(window -> ((Stage) window).getModality() == Modality.APPLICATION_MODAL)
-				.findFirst()
-				.orElse(null);
 	}
 
 	public static void selectFromComboBox(String item, String boxName) {

--- a/tools-ui/pom.xml
+++ b/tools-ui/pom.xml
@@ -26,7 +26,7 @@
 	<parent>
 		<artifactId>hedera-transaction-tool</artifactId>
 		<groupId>com.hedera.hashgraph</groupId>
-		<version>0.6.0</version>
+		<version>0.6.1</version>
 		<relativePath>../</relativePath>
 	</parent>
 
@@ -34,7 +34,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>tools-ui</artifactId>
-	<version>0.6.0</version>
+	<version>0.6.1</version>
 	<packaging>jar</packaging>
 
 	<!-- Project Properties -->
@@ -65,7 +65,7 @@
 		<dependency>
 			<groupId>com.hedera.hashgraph</groupId>
 			<artifactId>tools-core</artifactId>
-			<version>0.6.0</version>
+			<version>0.6.1</version>
 		</dependency>
 
 		<!-- SDK Dependency -->

--- a/tools-ui/src/main/java/com/hedera/hashgraph/client/ui/CreatePaneController.java
+++ b/tools-ui/src/main/java/com/hedera/hashgraph/client/ui/CreatePaneController.java
@@ -1621,6 +1621,8 @@ public class CreatePaneController implements GenericFileReadWriteAware {
 					return null;
 				}
 				break;
+			default:
+				break;
 		}
 		return input;
 	}

--- a/tools-ui/src/main/java/com/hedera/hashgraph/client/ui/CreatePaneController.java
+++ b/tools-ui/src/main/java/com/hedera/hashgraph/client/ui/CreatePaneController.java
@@ -60,6 +60,7 @@ import javafx.collections.FXCollections;
 import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
+import javafx.geometry.Pos;
 import javafx.scene.Node;
 import javafx.scene.control.Button;
 import javafx.scene.control.ChoiceBox;
@@ -439,13 +440,9 @@ public class CreatePaneController implements GenericFileReadWriteAware {
 	private void setupTransferFields() {
 		transferTableEvents(transferFromAccountIDTextField, transferFromAmountTextField, fromTransferTable,
 				acceptFromAccountButton, errorInvalidFromAccount);
-		fromTransferTable.prefWidthProperty().bind(fromHBox.widthProperty());
-		fromTransferTable.prefHeightProperty().bind(fromTransferTable.heightProperty().multiply(.4));
-
 		transferTableEvents(transferToAccountIDTextField, transferToAmountTextField, toTransferTable,
 				acceptToAccountButton, errorInvalidToAccount);
-		toTransferTable.prefWidthProperty().bind(toHBox.widthProperty());
-		toTransferTable.prefHeightProperty().bind(toTransferTable.heightProperty().multiply(.4));
+
 		transferFromAmountTextField.textProperty().addListener(
 				(observable, oldValue, newValue) -> fixNumericTextField(transferFromAmountTextField, newValue, "\\d*",
 						"[^\\d.]"));
@@ -1060,8 +1057,8 @@ public class CreatePaneController implements GenericFileReadWriteAware {
 		table.getColumns().clear();
 		table.getColumns().addAll(accountColumn, amountColumn);
 
-		accountColumn.prefWidthProperty().bind(table.widthProperty().multiply(0.395));
-		amountColumn.prefWidthProperty().bind(table.widthProperty().multiply(0.60));
+		accountColumn.prefWidthProperty().bind(table.widthProperty().multiply(0.6));
+		amountColumn.prefWidthProperty().bind(table.widthProperty().multiply(0.395));
 
 		accountColumn.setResizable(false);
 		amountColumn.setResizable(false);
@@ -1115,7 +1112,8 @@ public class CreatePaneController implements GenericFileReadWriteAware {
 		var newTransaction =
 				new AccountAmountStrings(account.getText(), stripHBarFormat(amount.getText()));
 
-		final var status = parseAddress(newTransaction.getAccountID()).getStatus();
+		final var status =
+				parseAddress(newTransaction.getAccountIdentifier().toReadableAccountAndChecksum()).getStatus();
 		if (status.equals(parseStatus.BAD_CHECKSUM) || status.equals(parseStatus.BAD_FORMAT)) {
 			account.setStyle(RED_BORDER_STYLE);
 			account.selectAll();
@@ -1132,6 +1130,7 @@ public class CreatePaneController implements GenericFileReadWriteAware {
 
 		thisTable.getItems().add(newTransaction);
 
+		transferCurrencyVBox.setAlignment(Pos.CENTER);
 		updateTotalAmount();
 		account.clear();
 		amount.clear();
@@ -1140,6 +1139,10 @@ public class CreatePaneController implements GenericFileReadWriteAware {
 
 	private void transferTableEvents(TextField accountIDTextField, TextField amountTextField,
 			TableView<AccountAmountStrings> table, Button acceptButton, Label errorLabel) {
+
+		table.prefWidthProperty().bind(transferCurrencyVBox.widthProperty().multiply(2).divide(3));
+		table.prefHeightProperty().bind(fromTransferTable.heightProperty().multiply(.4));
+
 
 		formatAccountTextField(accountIDTextField, errorLabel, amountTextField);
 
@@ -2386,8 +2389,11 @@ public class CreatePaneController implements GenericFileReadWriteAware {
 		}
 	}
 
-	private void setupTextFieldResizeProperty(TextField... textFields) {
-		for (TextField tf : textFields) {
+	private void setupTextFieldResizeProperty(final TextField... textFields) {
+		for (final TextField tf : textFields) {
+			tf.setMinWidth(300);
+			tf.setMaxWidth(800);
+			tf.setAlignment(Pos.CENTER_LEFT);
 			tf.textProperty().addListener((ov, prevText, currText) -> resizeTextField(tf, currText));
 		}
 

--- a/tools-ui/src/main/java/com/hedera/hashgraph/client/ui/CreatePaneController.java
+++ b/tools-ui/src/main/java/com/hedera/hashgraph/client/ui/CreatePaneController.java
@@ -1705,7 +1705,7 @@ public class CreatePaneController implements GenericFileReadWriteAware {
 		final var info = accountsInfoMap.getOrDefault(account, null);
 
 		// Key
-		if (!newKeyJSON.isJsonNull() && newKeyJSON.size() != 0) {
+		if (!newKeyJSON.isJsonNull() && newKeyJSON.size() != 0 && !newKeyJSON.equals(originalKey)) {
 			input.add(NEW_KEY_FIELD_NAME, newKeyJSON);
 		}
 

--- a/tools-ui/src/main/java/com/hedera/hashgraph/client/ui/utilities/AccountAmountStrings.java
+++ b/tools-ui/src/main/java/com/hedera/hashgraph/client/ui/utilities/AccountAmountStrings.java
@@ -19,6 +19,7 @@
 
 package com.hedera.hashgraph.client.ui.utilities;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.google.gson.JsonElement;
 import com.hedera.hashgraph.client.core.json.Identifier;
 
@@ -28,14 +29,8 @@ public class AccountAmountStrings {
 	private String amount;
 
 	public AccountAmountStrings(String accountID, String amount) {
-		if (accountID.contains(".")) {
-			this.accountID = accountID;
-		} else {
-			this.accountID = String.format("0.0.%s", accountID);
-		}
-
+		this.accountID = accountID;
 		var temp = amount.replace("-", "").replace(" ", "").replace("\u0127", "").replace(".", "");
-
 		this.amount = ((amount.contains("-")) ? "- " : "") + Utilities.setHBarFormat(
 				Long.parseLong(temp.substring(0, Math.min(temp.length(), 19))));
 
@@ -50,16 +45,12 @@ public class AccountAmountStrings {
 		return accountID;
 	}
 
-	public JsonElement getAccountAsJSON() {
-		return Identifier.parse(accountID).asJSON();
+	public Identifier getAccountIdentifier(){
+		return Identifier.parse(this.accountID);
 	}
 
-	public void setAccountID(String accountID) {
-		if (accountID.contains(".")) {
-			this.accountID = accountID;
-		} else {
-			this.accountID = String.format("0.0.%s", accountID);
-		}
+	public JsonElement getAccountAsJSON() {
+		return Identifier.parse(accountID).asJSON();
 	}
 
 	public String getAmount() {

--- a/tools-ui/src/main/java/com/hedera/hashgraph/client/ui/utilities/AccountAmountStrings.java
+++ b/tools-ui/src/main/java/com/hedera/hashgraph/client/ui/utilities/AccountAmountStrings.java
@@ -19,7 +19,6 @@
 
 package com.hedera.hashgraph.client.ui.utilities;
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.google.gson.JsonElement;
 import com.hedera.hashgraph.client.core.json.Identifier;
 
@@ -45,7 +44,7 @@ public class AccountAmountStrings {
 		return accountID;
 	}
 
-	public Identifier getAccountIdentifier(){
+	public Identifier getAccountIdentifier() {
 		return Identifier.parse(this.accountID);
 	}
 

--- a/tools-ui/src/main/java/com/hedera/hashgraph/client/ui/utilities/MnemonicPhraseHelper.java
+++ b/tools-ui/src/main/java/com/hedera/hashgraph/client/ui/utilities/MnemonicPhraseHelper.java
@@ -198,6 +198,11 @@ public class MnemonicPhraseHelper implements GenericFileReadWriteAware {
 
 		var password = NewPasswordPopup.display("Recovery phrase password",
 				"Enter your recovery phrase password. Frequently used passwords will not be accepted.");
+		while (password == null || password.length == 0) {
+			password = NewPasswordPopup.display("Recovery phrase password",
+					"A password is required to encrypt the recovery phrase, please try again.");
+		}
+
 		try {
 			if (password != null) {
 				properties.setHash(password);

--- a/tools-ui/src/main/resources/com/hedera/hashgraph/client/ui/CreatePane.fxml
+++ b/tools-ui/src/main/resources/com/hedera/hashgraph/client/ui/CreatePane.fxml
@@ -19,597 +19,475 @@
   -->
 
 <?import javafx.geometry.Insets?>
-<?import javafx.scene.control.*?>
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.control.ChoiceBox?>
+<?import javafx.scene.control.DatePicker?>
+<?import javafx.scene.control.Hyperlink?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.control.ScrollPane?>
+<?import javafx.scene.control.TableView?>
+<?import javafx.scene.control.TextArea?>
+<?import javafx.scene.control.TextField?>
 <?import javafx.scene.image.Image?>
 <?import javafx.scene.image.ImageView?>
-<?import javafx.scene.layout.*?>
+<?import javafx.scene.layout.AnchorPane?>
+<?import javafx.scene.layout.ColumnConstraints?>
+<?import javafx.scene.layout.GridPane?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.Region?>
+<?import javafx.scene.layout.RowConstraints?>
+<?import javafx.scene.layout.VBox?>
 <?import javafx.scene.text.Text?>
 <?import org.controlsfx.control.ToggleSwitch?>
-<AnchorPane fx:id="createAnchorPane" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0"
-			AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" xmlns="http://javafx.com/javafx/"
-			xmlns:fx="http://javafx.com/fxml/" fx:controller="com.hedera.hashgraph.client.ui.CreatePaneController">
-	<VBox fx:id="mainVBox" layoutX="5.0" layoutY="5.0"
-		  style="-fx-background-color: white; -fx-border-color: lightgrey white white white; -fx-border-width: 3;"
-		  AnchorPane.bottomAnchor="5.0" AnchorPane.leftAnchor="5.0" AnchorPane.rightAnchor="5.0"
-		  AnchorPane.topAnchor="5.0">
-		<TextField fx:id="loadTransactionTextField" maxHeight="1.0" minHeight="1.0"
-				   onKeyReleased="#loadFormFromTransactionTest" prefHeight="1.0" style="-fx-background-color: white;"/>
+
+<AnchorPane fx:id="createAnchorPane" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" xmlns="http://javafx.com/javafx/16" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.hedera.hashgraph.client.ui.CreatePaneController">
+	<VBox fx:id="mainVBox" layoutX="5.0" layoutY="5.0" style="-fx-background-color: white; -fx-border-color: lightgrey white white white; -fx-border-width: 3;" AnchorPane.bottomAnchor="5.0" AnchorPane.leftAnchor="5.0" AnchorPane.rightAnchor="5.0" AnchorPane.topAnchor="5.0">
+		<TextField fx:id="loadTransactionTextField" maxHeight="1.0" minHeight="1.0" onKeyReleased="#loadFormFromTransactionTest" prefHeight="1.0" style="-fx-background-color: white;" />
 		<HBox alignment="CENTER_LEFT" fillHeight="false" minHeight="80.0" spacing="20.0">
 			<GridPane hgap="5.0" vgap="5.0">
 				<columnConstraints>
-					<ColumnConstraints hgrow="SOMETIMES" minWidth="10.0"/>
-					<ColumnConstraints halignment="LEFT" hgrow="SOMETIMES" minWidth="10.0"/>
+					<ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" />
+					<ColumnConstraints halignment="LEFT" hgrow="SOMETIMES" minWidth="10.0" />
 				</columnConstraints>
 				<rowConstraints>
-					<RowConstraints minHeight="30.0" vgrow="SOMETIMES"/>
-					<RowConstraints maxHeight="30.0" minHeight="30.0" vgrow="SOMETIMES"/>
+					<RowConstraints minHeight="30.0" vgrow="SOMETIMES" />
+					<RowConstraints maxHeight="30.0" minHeight="30.0" vgrow="SOMETIMES" />
 				</rowConstraints>
-				<Label text="Transaction Type"/>
-				<ChoiceBox fx:id="selectTransactionType" onAction="#chooseTransactionTypeChangedAction"
-						   prefWidth="300.0"
-						   style="-fx-border-color: #0b9dfd; -fx-background-color: white; -fx-background-radius: 10; -fx-border-radius: 10;"
-						   GridPane.columnIndex="1"/>
-				<Button fx:id="browseTransactions" minWidth="70.0" mnemonicParsing="false"
-						onAction="#loadFormFromTransaction" prefWidth="300.0"
-						style="-fx-background-color: white; -fx-border-color: #0b9dfd; -fx-text-fill: #0b9dfd; -fx-background-radius: 10; -fx-border-radius: 10;"
-						text="IMPORT TRANSACTION" GridPane.columnIndex="1" GridPane.rowIndex="1"/>
+				<Label text="Transaction Type" />
+				<ChoiceBox fx:id="selectTransactionType" onAction="#chooseTransactionTypeChangedAction" prefWidth="300.0" style="-fx-border-color: #0b9dfd; -fx-background-color: white; -fx-background-radius: 10; -fx-border-radius: 10;" GridPane.columnIndex="1" />
+				<Button fx:id="browseTransactions" minWidth="70.0" mnemonicParsing="false" onAction="#loadFormFromTransaction" prefWidth="300.0" style="-fx-background-color: white; -fx-border-color: #0b9dfd; -fx-text-fill: #0b9dfd; -fx-background-radius: 10; -fx-border-radius: 10;" text="IMPORT TRANSACTION" GridPane.columnIndex="1" GridPane.rowIndex="1" />
 			</GridPane>
-			<Region HBox.hgrow="ALWAYS"/>
-			<HBox fx:id="createChoiceHBox"/>
+			<Region HBox.hgrow="ALWAYS" />
+			<HBox fx:id="createChoiceHBox" />
 			<VBox.margin>
-				<Insets bottom="10.0" left="15.0" right="15.0"/>
+				<Insets bottom="10.0" left="15.0" right="15.0" />
 			</VBox.margin>
 		</HBox>
-		<ScrollPane fx:id="createScrollPane" fitToHeight="true" fitToWidth="true"
-					style="-fx-background-color: white; -fx-border-color: white;">
+		<ScrollPane fx:id="createScrollPane" fitToHeight="true" fitToWidth="true" style="-fx-background-color: white; -fx-border-color: white;">
 			<VBox spacing="20.0" style="-fx-background-color: white; -fx-border-color: white;">
 				<VBox fx:id="commentsVBox" spacing="10.0" style="-fx-background-color: white;">
-					<Label text="Comments:"/>
-					<TextArea fx:id="createCommentsTextArea" maxHeight="200" minHeight="100.0" prefHeight="100"
-							  prefRowCount="5" prefWidth="200.0" promptText="Your comments" wrapText="true"/>
+					<Label text="Comments:" />
+					<TextArea fx:id="createCommentsTextArea" maxHeight="200" minHeight="100.0" prefHeight="100" prefRowCount="5" prefWidth="200.0" promptText="Your comments" wrapText="true" />
 					<HBox>
-						<Region HBox.hgrow="ALWAYS"/>
-						<Label fx:id="createCharsLeft" text="Characters remaining: 255"/>
+						<Region HBox.hgrow="ALWAYS" />
+						<Label fx:id="createCharsLeft" text="Characters remaining: 255" />
 					</HBox>
 					<padding>
-						<Insets left="15.0" right="15.0"/>
+						<Insets left="15.0" right="15.0" />
 					</padding>
 				</VBox>
 				<VBox fx:id="freezeChoiceVBox" spacing="25.0">
 					<VBox.margin>
-						<Insets left="15.0" right="15.0" top="15.0"/>
+						<Insets left="15.0" right="15.0" top="15.0" />
 					</VBox.margin>
-					<Label text="Freeze type"/>
-					<ChoiceBox fx:id="freezeTypeChoiceBox" minWidth="250.0"
-							   style="-fx-background-color: white; -fx-border-color: #0b9dfd; -fx-background-radius: 10; -fx-border-radius: 10;"/>
+					<Label text="Freeze type" />
+					<ChoiceBox fx:id="freezeTypeChoiceBox" minWidth="250.0" style="-fx-background-color: white; -fx-border-color: #0b9dfd; -fx-background-radius: 10; -fx-border-radius: 10;" />
 				</VBox>
 				<VBox fx:id="accountIDToUpdateVBox" spacing="10.0">
 					<VBox.margin>
-						<Insets left="15.0" right="15.0" top="15.0"/>
+						<Insets left="15.0" right="15.0" top="15.0" />
 					</VBox.margin>
-					<Label text="Account to update"/>
+					<Label text="Account to update" />
 					<HBox alignment="CENTER_LEFT" spacing="20.0">
-						<TextField fx:id="updateAccountID" alignment="CENTER" maxWidth="-Infinity" minWidth="300.0"
-								   promptText="X.X.XXXX" style="-fx-border-radius: 10; -fx-background-radius: 10;"/>
-						<ImageView fitHeight="15.0" fitWidth="15.0" pickOnBounds="true" preserveRatio="true"
-								   visible="false">
-							<Image url="@../../../../../icons/greencheck.png"/>
+						<TextField fx:id="updateAccountID" alignment="CENTER" maxWidth="-Infinity" minWidth="300.0" promptText="X.X.XXXX" style="-fx-border-radius: 10; -fx-background-radius: 10;" />
+						<ImageView fitHeight="15.0" fitWidth="15.0" pickOnBounds="true" preserveRatio="true" visible="false">
+							<Image url="@../../../../../icons/greencheck.png" />
 						</ImageView>
-						<Label fx:id="invalidUpdateAccountToUpdate" text="Cannot recognize account" textFill="RED"
-							   visible="false"/>
+						<Label fx:id="invalidUpdateAccountToUpdate" text="Cannot recognize account" textFill="RED" visible="false" />
 						<padding>
-							<Insets top="15.0"/>
+							<Insets top="15.0" />
 						</padding>
 					</HBox>
 				</VBox>
 				<VBox fx:id="fileIDToUpdateVBox" layoutX="26.0" layoutY="215.0" spacing="10.0">
 					<VBox.margin>
-						<Insets left="15.0" right="15.0" top="15.0"/>
+						<Insets left="15.0" right="15.0" top="15.0" />
 					</VBox.margin>
-					<Label text="File to update"/>
+					<Label text="File to update" />
 					<HBox alignment="CENTER_LEFT" spacing="20.0">
 						<padding>
-							<Insets top="15.0"/>
+							<Insets top="15.0" />
 						</padding>
-						<TextField fx:id="updateFileID" alignment="CENTER" maxWidth="-Infinity" minWidth="300.0"
-								   promptText="X.X.XXXX" style="-fx-border-radius: 10; -fx-background-radius: 10;"/>
-						<ImageView fitHeight="15.0" fitWidth="15.0" pickOnBounds="true" preserveRatio="true"
-								   visible="false">
-							<Image url="@../../../../../icons/greencheck.png"/>
+						<TextField fx:id="updateFileID" alignment="CENTER" maxWidth="-Infinity" minWidth="300.0" promptText="X.X.XXXX" style="-fx-border-radius: 10; -fx-background-radius: 10;" />
+						<ImageView fitHeight="15.0" fitWidth="15.0" pickOnBounds="true" preserveRatio="true" visible="false">
+							<Image url="@../../../../../icons/greencheck.png" />
 						</ImageView>
-						<Label fx:id="invalidUpdateFileToUpdate" text="Cannot recognize file" textFill="RED"
-							   visible="false"/>
+						<Label fx:id="invalidUpdateFileToUpdate" text="Cannot recognize file" textFill="RED" visible="false" />
 					</HBox>
 				</VBox>
 				<HBox fx:id="systemSlidersHBox" spacing="50.0">
 					<padding>
-						<Insets left="15.0" right="15.0" top="15.0"/>
+						<Insets left="15.0" right="15.0" top="15.0" />
 					</padding>
 					<GridPane vgap="20.0">
 						<columnConstraints>
-							<ColumnConstraints minWidth="150.0"/>
-							<ColumnConstraints halignment="LEFT" minWidth="10.0"/>
+							<ColumnConstraints minWidth="150.0" />
+							<ColumnConstraints halignment="LEFT" minWidth="10.0" />
 						</columnConstraints>
 						<rowConstraints>
-							<RowConstraints vgrow="SOMETIMES"/>
+							<RowConstraints vgrow="SOMETIMES" />
 						</rowConstraints>
-						<Label text="Action"/>
-						<ChoiceBox fx:id="systemActionChoiceBox" minWidth="250.0"
-								   style="-fx-background-color: white; -fx-border-color: #0b9dfd; -fx-background-radius: 10; -fx-border-radius: 10;"
-								   GridPane.columnIndex="1"/>
+						<Label text="Action" />
+						<ChoiceBox fx:id="systemActionChoiceBox" minWidth="250.0" style="-fx-background-color: white; -fx-border-color: #0b9dfd; -fx-background-radius: 10; -fx-border-radius: 10;" GridPane.columnIndex="1" />
 					</GridPane>
 					<GridPane layoutX="10.0" layoutY="10.0" vgap="20.0">
 						<columnConstraints>
-							<ColumnConstraints minWidth="150.0"/>
-							<ColumnConstraints halignment="LEFT" minWidth="10.0"/>
+							<ColumnConstraints minWidth="150.0" />
+							<ColumnConstraints halignment="LEFT" minWidth="10.0" />
 						</columnConstraints>
 						<rowConstraints>
-							<RowConstraints vgrow="SOMETIMES"/>
+							<RowConstraints vgrow="SOMETIMES" />
 						</rowConstraints>
-						<Label text="Type"/>
-						<ChoiceBox fx:id="systemTypeChoiceBox" minWidth="250.0"
-								   style="-fx-background-color: white; -fx-border-color: #0b9dfd; -fx-background-radius: 10; -fx-border-radius: 10;"
-								   GridPane.columnIndex="1"/>
+						<Label text="Type" />
+						<ChoiceBox fx:id="systemTypeChoiceBox" minWidth="250.0" style="-fx-background-color: white; -fx-border-color: #0b9dfd; -fx-background-radius: 10; -fx-border-radius: 10;" GridPane.columnIndex="1" />
 					</GridPane>
 				</HBox>
 				<VBox fx:id="commonFieldsVBox" spacing="20.0" style="-fx-background-color: white;">
 					<padding>
-						<Insets left="15.0" right="15.0" top="15.0"/>
+						<Insets left="15.0" right="15.0" top="15.0" />
 					</padding>
 					<VBox spacing="10.0">
-						<Label text="Transaction will be submitted on"/>
+						<Label text="Transaction will be submitted on" />
 						<HBox alignment="CENTER_LEFT" spacing="20.0" VBox.vgrow="ALWAYS">
-							<DatePicker fx:id="datePicker"/>
-							<Label minWidth="11.0" text="at"/>
+							<DatePicker fx:id="datePicker" />
+							<Label minWidth="11.0" text="at" />
 							<HBox alignment="CENTER_LEFT" spacing="5.0">
-								<TextField fx:id="hourField" alignment="CENTER" maxWidth="50.0" minWidth="50.0"
-										   prefWidth="50.0" style="-fx-border-radius: 5; -fx-background-radius: 5;"
-										   text="00"/>
-								<Label text=":"/>
-								<TextField fx:id="minuteField" alignment="CENTER" maxWidth="50.0" minWidth="50.0"
-										   prefWidth="50.0" style="-fx-border-radius: 5; -fx-background-radius: 5;"
-										   text="00"/>
-								<Label layoutX="65.0" layoutY="15.0" text=":"/>
-								<TextField fx:id="secondsField" alignment="CENTER" layoutX="74.0" layoutY="10.0"
-										   maxWidth="50.0" minWidth="50.0" prefWidth="50.0"
-										   style="-fx-border-radius: 5; -fx-background-radius: 5;" text="00"/>
-								<Label layoutX="128.0" layoutY="16.0" text="."/>
-								<TextField fx:id="nanosField" alignment="CENTER" layoutX="136.0" layoutY="11.0"
-										   minWidth="39.0" prefHeight="27.0" prefWidth="150.0"
-										   style="-fx-border-radius: 5; -fx-background-radius: 5;" text="000000000"/>
-								<HBox fx:id="timeZoneHBox"/>
+								<TextField fx:id="hourField" alignment="CENTER" maxWidth="50.0" minWidth="50.0" prefWidth="50.0" style="-fx-border-radius: 5; -fx-background-radius: 5;" text="00" />
+								<Label text=":" />
+								<TextField fx:id="minuteField" alignment="CENTER" maxWidth="50.0" minWidth="50.0" prefWidth="50.0" style="-fx-border-radius: 5; -fx-background-radius: 5;" text="00" />
+								<Label layoutX="65.0" layoutY="15.0" text=":" />
+								<TextField fx:id="secondsField" alignment="CENTER" layoutX="74.0" layoutY="10.0" maxWidth="50.0" minWidth="50.0" prefWidth="50.0" style="-fx-border-radius: 5; -fx-background-radius: 5;" text="00" />
+								<Label layoutX="128.0" layoutY="16.0" text="." />
+								<TextField fx:id="nanosField" alignment="CENTER" layoutX="136.0" layoutY="11.0" minWidth="39.0" prefHeight="27.0" prefWidth="150.0" style="-fx-border-radius: 5; -fx-background-radius: 5;" text="000000000" />
+								<HBox fx:id="timeZoneHBox" />
 							</HBox>
 							<HBox spacing="2.0">
-								<Button fx:id="setNowValidStart" minWidth="70.0" mnemonicParsing="false"
-										style="-fx-background-color: white; -fx-border-color: #0b9dfd; -fx-text-fill: #0b9dfd; -fx-background-radius: 10; -fx-border-radius: 10;"
-										text="Now"/>
-								<Button fx:id="nowTimeToolTip" alignment="TOP_CENTER" mnemonicParsing="false"
-										style="-fx-background-color: white; -fx-border-color: white;">
+								<Button fx:id="setNowValidStart" minWidth="70.0" mnemonicParsing="false" style="-fx-background-color: white; -fx-border-color: #0b9dfd; -fx-text-fill: #0b9dfd; -fx-background-radius: 10; -fx-border-radius: 10;" text="Now" />
+								<Button fx:id="nowTimeToolTip" alignment="TOP_CENTER" mnemonicParsing="false" style="-fx-background-color: white; -fx-border-color: white;">
 									<graphic>
-										<ImageView fitHeight="15.0" fitWidth="15.0" pickOnBounds="true"
-												   preserveRatio="true">
-											<Image url="@../../../../../icons/helpIcon.png"/>
+										<ImageView fitHeight="15.0" fitWidth="15.0" pickOnBounds="true" preserveRatio="true">
+											<Image url="@../../../../../icons/helpIcon.png" />
 										</ImageView>
 									</graphic>
 									<padding>
-										<Insets bottom="7.0"/>
+										<Insets bottom="7.0" />
 									</padding>
 								</Button>
 							</HBox>
 						</HBox>
-						<Label fx:id="createUTCTimeLabel"/>
-						<Label fx:id="invalidDate" text="Invalid transaction submission time" textFill="RED"
-							   visible="false"/>
+						<Label fx:id="createUTCTimeLabel" />
+						<Label fx:id="invalidDate" text="Invalid transaction submission time" textFill="RED" visible="false" />
 					</VBox>
 					<VBox spacing="10.0" VBox.vgrow="ALWAYS">
-						<Label text="Memo field"/>
+						<Label text="Memo field" />
 						<HBox alignment="CENTER_LEFT" spacing="20.0" VBox.vgrow="ALWAYS">
-							<TextArea fx:id="memoField" maxWidth="600.0" minWidth="600.0" prefRowCount="1"
-									  prefWidth="600.0" wrapText="true"/>
-							<ImageView fitHeight="15.0" fitWidth="15.0" pickOnBounds="true" preserveRatio="true"
-									   visible="false">
-								<Image url="@../../../../../icons/greencheck.png"/>
+							<TextArea fx:id="memoField" maxWidth="600.0" minWidth="600.0" prefRowCount="1" prefWidth="600.0" wrapText="true" />
+							<ImageView fitHeight="15.0" fitWidth="15.0" pickOnBounds="true" preserveRatio="true" visible="false">
+								<Image url="@../../../../../icons/greencheck.png" />
 							</ImageView>
-							<Label text="Label" visible="false"/>
+							<Label text="Label" visible="false" />
 						</HBox>
 					</VBox>
 					<VBox spacing="10.0">
-						<Label text="Payer account"/>
+						<Label text="Payer account" />
 						<HBox alignment="CENTER_LEFT" spacing="20.0" VBox.vgrow="ALWAYS">
-							<TextField fx:id="feePayerAccountField" alignment="CENTER" maxWidth="1.7976931348623157E308"
-									   minWidth="300.0" promptText="X.X.XXXX"
-									   style="-fx-border-radius: 10; -fx-background-radius: 10;"/>
-							<ImageView fitHeight="15.0" fitWidth="15.0" pickOnBounds="true" preserveRatio="true"
-									   visible="false">
-								<Image url="@../../../../../icons/greencheck.png"/>
+							<TextField fx:id="feePayerAccountField" alignment="CENTER" maxWidth="1.7976931348623157E308" minWidth="300.0" promptText="X.X.XXXX" style="-fx-border-radius: 10; -fx-background-radius: 10;" />
+							<ImageView fitHeight="15.0" fitWidth="15.0" pickOnBounds="true" preserveRatio="true" visible="false">
+								<Image url="@../../../../../icons/greencheck.png" />
 							</ImageView>
-							<Label fx:id="invalidFeePayer" text="Cannot recognize account" textFill="RED"
-								   visible="false"/>
+							<Label fx:id="invalidFeePayer" text="Cannot recognize account" textFill="RED" visible="false" />
 						</HBox>
 					</VBox>
 					<VBox spacing="10.0">
-						<Label text="Submit to node"/>
+						<Label text="Submit to node" />
 						<HBox alignment="CENTER_LEFT" spacing="20.0" VBox.vgrow="ALWAYS">
-							<TextField fx:id="nodeAccountField" alignment="CENTER" maxWidth="-Infinity" minWidth="300.0"
-									   promptText="X.X.XXXX" style="-fx-border-radius: 10; -fx-background-radius: 10;"/>
-							<ImageView fitHeight="15.0" fitWidth="15.0" pickOnBounds="true" preserveRatio="true"
-									   visible="false">
-								<Image url="@../../../../../icons/greencheck.png"/>
+							<TextField fx:id="nodeAccountField" alignment="CENTER" maxWidth="-Infinity" minWidth="300.0" promptText="X.X.XXXX" style="-fx-border-radius: 10; -fx-background-radius: 10;" />
+							<ImageView fitHeight="15.0" fitWidth="15.0" pickOnBounds="true" preserveRatio="true" visible="false">
+								<Image url="@../../../../../icons/greencheck.png" />
 							</ImageView>
-							<Label fx:id="invalidNode" text="Cannot recognize account" textFill="RED" visible="false"/>
+							<Label fx:id="invalidNode" text="Cannot recognize account" textFill="RED" visible="false" />
 						</HBox>
 					</VBox>
 					<VBox spacing="10.0">
-						<Label text="Maximum transaction fee"/>
+						<Label text="Maximum transaction fee" />
 						<HBox alignment="CENTER_LEFT" spacing="20.0" VBox.vgrow="ALWAYS">
-							<TextField fx:id="transactionFee" maxWidth="300.0" minWidth="300.0" prefWidth="300.0"
-									   style="-fx-border-radius: 10; -fx-background-radius: 10;" text="0"/>
-							<Label text="ћ"/>
-							<Label fx:id="invalidTransactionFee" text="Invalid initial balance" textFill="RED"
-								   visible="false"/>
+							<TextField fx:id="transactionFee" maxWidth="300.0" minWidth="300.0" prefWidth="300.0" style="-fx-border-radius: 10; -fx-background-radius: 10;" text="0" />
+							<Label text="ћ" />
+							<Label fx:id="invalidTransactionFee" text="Invalid initial balance" textFill="RED" visible="false" />
 						</HBox>
 					</VBox>
 				</VBox>
 				<VBox fx:id="createAccountVBox" alignment="CENTER" spacing="20.0" style="-fx-background-color: white;">
 					<padding>
-						<Insets bottom="15.0" left="15.0" right="15.0" top="10.0"/>
+						<Insets bottom="15.0" left="15.0" right="15.0" top="10.0" />
 					</padding>
 					<VBox layoutX="28.0" layoutY="102.0" spacing="10.0">
-						<Label text="Initial Balance"/>
+						<Label text="Initial Balance" />
 						<HBox alignment="CENTER_LEFT" spacing="20.0" VBox.vgrow="ALWAYS">
-							<TextField fx:id="createInitialBalance" maxWidth="300.0" minWidth="300.0" prefWidth="300.0"
-									   style="-fx-border-radius: 10; -fx-background-radius: 10;" text="0"/>
-							<Label text="ћ"/>
-							<Label fx:id="invalidCreateInitialBalance" text="Invalid initial balance" textFill="RED"
-								   visible="false"/>
+							<TextField fx:id="createInitialBalance" maxWidth="300.0" minWidth="300.0" prefWidth="300.0" style="-fx-border-radius: 10; -fx-background-radius: 10;" text="0" />
+							<Label text="ћ" />
+							<Label fx:id="invalidCreateInitialBalance" text="Invalid initial balance" textFill="RED" visible="false" />
 						</HBox>
 					</VBox>
 					<VBox layoutX="25.0" layoutY="617.0" spacing="10.0">
-						<Label text="New account key"/>
+						<Label text="New account key" />
 						<HBox alignment="CENTER_LEFT" spacing="50.0">
-							<ScrollPane fx:id="createNewKey" hbarPolicy="NEVER" minHeight="150.0" minWidth="-Infinity"
-										prefHeight="150.0" prefWidth="300.0"
-										style="-fx-background-color: white; -fx-border-color: grey;" visible="false"/>
+							<ScrollPane fx:id="createNewKey" hbarPolicy="NEVER" minHeight="150.0" minWidth="-Infinity" prefHeight="150.0" prefWidth="300.0" style="-fx-background-color: white; -fx-border-color: grey;" visible="false" />
 							<GridPane hgap="5.0" vgap="5.0">
 								<columnConstraints>
-									<ColumnConstraints hgrow="SOMETIMES" minWidth="-Infinity"/>
-									<ColumnConstraints hgrow="SOMETIMES"/>
+									<ColumnConstraints hgrow="SOMETIMES" minWidth="-Infinity" />
+									<ColumnConstraints hgrow="SOMETIMES" />
 								</columnConstraints>
 								<rowConstraints>
-									<RowConstraints minHeight="-Infinity" vgrow="NEVER"/>
-									<RowConstraints minHeight="-Infinity" vgrow="NEVER"/>
-									<RowConstraints minHeight="-Infinity" vgrow="NEVER"/>
+									<RowConstraints minHeight="-Infinity" vgrow="NEVER" />
+									<RowConstraints minHeight="-Infinity" vgrow="NEVER" />
+									<RowConstraints minHeight="-Infinity" vgrow="NEVER" />
 								</rowConstraints>
-								<Button fx:id="createKeyButton" maxWidth="1.7976931348623157E308"
-										mnemonicParsing="false"
-										style="-fx-background-color: white; -fx-border-color: #0b9dfd; -fx-text-fill: #0b9dfd; -fx-border-radius: 10; -fx-background-radius: 10;"
-										text="EDIT KEY" GridPane.halignment="CENTER" GridPane.hgrow="ALWAYS"
-										GridPane.valignment="CENTER"/>
-								<HBox fx:id="copyFromAccountHBox" spacing="5.0" GridPane.columnIndex="1"
-									  GridPane.rowIndex="2"/>
+								<Button fx:id="createKeyButton" maxWidth="1.7976931348623157E308" mnemonicParsing="false" style="-fx-background-color: white; -fx-border-color: #0b9dfd; -fx-text-fill: #0b9dfd; -fx-border-radius: 10; -fx-background-radius: 10;" text="EDIT KEY" GridPane.halignment="CENTER" GridPane.hgrow="ALWAYS" GridPane.valignment="CENTER" />
+								<HBox fx:id="copyFromAccountHBox" spacing="5.0" GridPane.columnIndex="1" GridPane.rowIndex="2" />
 							</GridPane>
-							<Label fx:id="invalidCreateNewKey" text="A new key must be specified" textFill="RED"
-								   visible="false"/>
+							<Label fx:id="invalidCreateNewKey" text="A new key must be specified" textFill="RED" visible="false" />
 						</HBox>
 					</VBox>
 					<VBox spacing="10.0">
-						<Label text="Auto renew period"/>
+						<Label text="Auto renew period" />
 						<HBox alignment="CENTER_LEFT" spacing="20.0" VBox.vgrow="ALWAYS">
-							<TextField fx:id="createAutoRenew" maxWidth="300.0" minWidth="300.0" prefWidth="300.0"
-									   style="-fx-border-radius: 10; -fx-background-radius: 10;" text="17775"/>
-							<Label text="s"/>
-							<ImageView fitHeight="15.0" fitWidth="15.0" pickOnBounds="true" preserveRatio="true"
-									   visible="false">
-								<Image url="@../../../../../icons/greencheck.png"/>
+							<TextField fx:id="createAutoRenew" maxWidth="300.0" minWidth="300.0" prefWidth="300.0" style="-fx-border-radius: 10; -fx-background-radius: 10;" text="17775" />
+							<Label text="s" />
+							<ImageView fitHeight="15.0" fitWidth="15.0" pickOnBounds="true" preserveRatio="true" visible="false">
+								<Image url="@../../../../../icons/greencheck.png" />
 							</ImageView>
-							<Label fx:id="invalidCreateAutoRenew" text="Invalid auto renew period" textFill="RED"
-								   visible="false"/>
+							<Label fx:id="invalidCreateAutoRenew" text="Invalid auto renew period" textFill="RED" visible="false" />
 						</HBox>
 					</VBox>
 					<VBox layoutX="28.0" layoutY="546.0" spacing="10.0">
 						<HBox spacing="20.0">
-							<Label text="Receiver signature required"/>
-							<ToggleSwitch fx:id="createSignatureRequired"/>
-							<Label fx:id="createRSRLabel" layoutX="10.0" layoutY="10.0" text="false"/>
+							<Label text="Receiver signature required" />
+							<ToggleSwitch fx:id="createSignatureRequired" />
+							<Label fx:id="createRSRLabel" layoutX="10.0" layoutY="10.0" text="false" />
 						</HBox>
 					</VBox>
 				</VBox>
 				<VBox fx:id="updateAccountVBox" alignment="CENTER" spacing="20.0" style="-fx-background-color: white;">
 					<padding>
-						<Insets bottom="15.0" left="15.0" right="15.0" top="10.0"/>
+						<Insets bottom="15.0" left="15.0" right="15.0" top="10.0" />
 					</padding>
-					<VBox layoutX="28.0" layoutY="28.0" spacing="10.0"/>
+					<VBox layoutX="28.0" layoutY="28.0" spacing="10.0" />
 					<VBox layoutX="25.0" layoutY="617.0" spacing="10.0">
 						<VBox spacing="10.0">
-							<Label text="New account key"/>
+							<Label text="New account key" />
 							<HBox alignment="CENTER_LEFT" spacing="20.0">
 								<VBox spacing="2.0">
-									<Label maxWidth="1.7976931348623157E308" minWidth="-Infinity"
-										   text="Original Value"/>
-									<ScrollPane fx:id="updateOriginalKey" minHeight="150.0" minWidth="-Infinity"
-												prefHeight="150.0" prefWidth="300.0"
-												style="-fx-background-color: white; -fx-border-color: grey;">
+									<Label maxWidth="1.7976931348623157E308" minWidth="-Infinity" text="Original Value" />
+									<ScrollPane fx:id="updateOriginalKey" minHeight="150.0" minWidth="-Infinity" prefHeight="150.0" prefWidth="300.0" style="-fx-background-color: white; -fx-border-color: grey;">
 									</ScrollPane>
 								</VBox>
 								<VBox spacing="2.0">
-									<Label fx:id="newValueLabel" maxWidth="1.7976931348623157E308" minWidth="-Infinity"
-										   text="New Value" visible="false"/>
+									<Label fx:id="newValueLabel" maxWidth="1.7976931348623157E308" minWidth="-Infinity" text="New Value" visible="false" />
 
-									<ScrollPane fx:id="updateNewKey" minHeight="150.0" minWidth="-Infinity"
-												prefHeight="150.0" prefWidth="300.0"
-												style="-fx-background-color: white; -fx-border-color: grey;"
-												visible="false">
+									<ScrollPane fx:id="updateNewKey" minHeight="150.0" minWidth="-Infinity" prefHeight="150.0" prefWidth="300.0" style="-fx-background-color: white; -fx-border-color: grey;" visible="false">
 									</ScrollPane>
 								</VBox>
 								<GridPane alignment="CENTER" hgap="5.0" vgap="5.0">
 									<columnConstraints>
-										<ColumnConstraints hgrow="SOMETIMES" minWidth="-Infinity"/>
-										<ColumnConstraints hgrow="SOMETIMES"/>
+										<ColumnConstraints hgrow="SOMETIMES" minWidth="-Infinity" />
+										<ColumnConstraints hgrow="SOMETIMES" />
 									</columnConstraints>
 									<rowConstraints>
-										<RowConstraints minHeight="10.0" vgrow="NEVER"/>
-										<RowConstraints minHeight="-Infinity" vgrow="NEVER"/>
-										<RowConstraints minHeight="-Infinity" vgrow="NEVER"/>
+										<RowConstraints minHeight="10.0" vgrow="NEVER" />
+										<RowConstraints minHeight="-Infinity" vgrow="NEVER" />
+										<RowConstraints minHeight="-Infinity" vgrow="NEVER" />
 									</rowConstraints>
-									<Button fx:id="updateKeyButton" maxWidth="1.7976931348623157E308"
-											mnemonicParsing="false"
-											style="-fx-background-color: white; -fx-border-color: #0b9dfd; -fx-text-fill: #0b9dfd; -fx-border-radius: 10; -fx-background-radius: 10;"
-											text="MODIFY KEY" GridPane.hgrow="ALWAYS"/>
-									<HBox fx:id="updateCopyFromAccountHBox" spacing="5.0" GridPane.columnIndex="1"
-										  GridPane.rowIndex="2"/>
+									<Button fx:id="updateKeyButton" maxWidth="1.7976931348623157E308" mnemonicParsing="false" style="-fx-background-color: white; -fx-border-color: #0b9dfd; -fx-text-fill: #0b9dfd; -fx-border-radius: 10; -fx-background-radius: 10;" text="MODIFY KEY" GridPane.hgrow="ALWAYS" />
+									<HBox fx:id="updateCopyFromAccountHBox" spacing="5.0" GridPane.columnIndex="1" GridPane.rowIndex="2" />
 								</GridPane>
-								<Label fx:id="invalidUpdateNewKey" text="Please choose an account to update first."
-									   textFill="RED" visible="false" wrapText="true"/>
+								<Label fx:id="invalidUpdateNewKey" text="Please choose an account to update first." textFill="RED" visible="false" wrapText="true" />
 							</HBox>
 						</VBox>
 					</VBox>
 					<VBox spacing="10.0">
-						<Label text="Auto renew period"/>
+						<Label text="Auto renew period" />
 						<HBox alignment="CENTER_LEFT" spacing="20.0" VBox.vgrow="ALWAYS">
-							<Label minWidth="77.0" text="Original Value"/>
-							<TextField fx:id="updateARPOriginal" disable="true" editable="false"
-									   focusTraversable="false" maxWidth="250.0" minWidth="250.0" prefWidth="250.0"
-									   promptText="unknown" style="-fx-border-radius: 10; -fx-background-radius: 10;"/>
-							<Label minWidth="60.0" text="New Value"/>
-							<TextField fx:id="updateAutoRenew" maxWidth="250.0" minWidth="250.0" prefWidth="250.0"
-									   style="-fx-border-radius: 10; -fx-background-radius: 10;"/>
-							<Label text="s"/>
-							<Label fx:id="invalidUpdatedAutoRenew" text="Invalid auto renew period" textFill="RED"
-								   visible="false"/>
+							<Label minWidth="77.0" text="Original Value" />
+							<TextField fx:id="updateARPOriginal" disable="true" editable="false" focusTraversable="false" maxWidth="250.0" minWidth="250.0" prefWidth="250.0" promptText="unknown" style="-fx-border-radius: 10; -fx-background-radius: 10;" />
+							<Label minWidth="60.0" text="New Value" />
+							<TextField fx:id="updateAutoRenew" maxWidth="250.0" minWidth="250.0" prefWidth="250.0" style="-fx-border-radius: 10; -fx-background-radius: 10;" />
+							<Label text="s" />
+							<Label fx:id="invalidUpdatedAutoRenew" text="Invalid auto renew period" textFill="RED" visible="false" />
 						</HBox>
 					</VBox>
 					<VBox layoutX="28.0" layoutY="546.0" spacing="10.0">
 						<HBox spacing="20.0">
-							<Label text="Receiver signature required"/>
-							<Label text="Original Value"/>
-							<Label fx:id="updateRSROriginal" alignment="CENTER" minWidth="26.0"
-								   style="-fx-text-fill: grey;" text="???"/>
-							<Label text="New Value"/>
-							<ToggleSwitch fx:id="updateReceiverSignatureRequired"/>
-							<Label fx:id="updateRSRLabel" text="false"/>
+							<Label text="Receiver signature required" />
+							<Label text="Original Value" />
+							<Label fx:id="updateRSROriginal" alignment="CENTER" minWidth="26.0" style="-fx-text-fill: grey;" text="???" />
+							<Label text="New Value" />
+							<ToggleSwitch fx:id="updateReceiverSignatureRequired" />
+							<Label fx:id="updateRSRLabel" text="false" />
 						</HBox>
 					</VBox>
 				</VBox>
-				<VBox fx:id="transferCurrencyVBox" alignment="CENTER" spacing="20.0"
-					  style="-fx-background-color: white;">
+				<VBox fx:id="transferCurrencyVBox" alignment="CENTER" spacing="20.0" style="-fx-background-color: white;">
 					<padding>
-						<Insets bottom="15.0" left="15.0" right="15.0" top="10.0"/>
+						<Insets bottom="15.0" left="15.0" right="15.0" top="10.0" />
 					</padding>
-					<VBox maxHeight="1.7976931348623157E308" maxWidth="-Infinity" spacing="20.0">
-						<VBox fx:id="fromAccountsVBox" maxHeight="1.7976931348623157E308" maxWidth="-Infinity"
-							  spacing="10.0">
-							<Label text="From account(s)"/>
-							<TableView fx:id="fromTransferTable" focusTraversable="false" maxHeight="-Infinity"
-									   maxWidth="-Infinity"/>
-							<HBox fx:id="fromHBox" alignment="CENTER_LEFT" maxHeight="-Infinity" maxWidth="-Infinity"
-								  spacing="20.0">
-								<TextField fx:id="transferFromAccountIDTextField" alignment="CENTER"
-										   promptText="X.X.XXXX"
-										   style="-fx-background-radius: 10; -fx-border-radius: 10;"/>
-								<TextField fx:id="transferFromAmountTextField" layoutX="10.0" layoutY="10.0"
-										   style="-fx-background-radius: 10; -fx-border-radius: 10;"/>
-								<Label text="ћ"/>
-								<Button fx:id="acceptFromAccountButton" mnemonicParsing="false" prefWidth="150.0"
-										style="-fx-background-color: #0B9DFD; -fx-border-color: #0b9bfd; -fx-text-fill: white; -fx-border-radius: 10; -fx-background-radius: 10;"
-										text="ACCEPT" textAlignment="CENTER"/>
+					<VBox alignment="TOP_CENTER" maxHeight="1.7976931348623157E308" maxWidth="-Infinity" spacing="20.0">
+						<VBox fx:id="fromAccountsVBox" alignment="TOP_CENTER" maxHeight="1.7976931348623157E308" maxWidth="-Infinity" spacing="10.0">
+							<Label text="From account(s)" />
+							<TableView fx:id="fromTransferTable" focusTraversable="false" maxHeight="-Infinity" maxWidth="-Infinity" />
+							<HBox fx:id="fromHBox" alignment="CENTER_LEFT" maxHeight="-Infinity" maxWidth="-Infinity" spacing="20.0">
+								<TextField fx:id="transferFromAccountIDTextField" alignment="CENTER" promptText="X.X.XXXX" style="-fx-background-radius: 10; -fx-border-radius: 10;" />
+								<TextField fx:id="transferFromAmountTextField" layoutX="10.0" layoutY="10.0" style="-fx-background-radius: 10; -fx-border-radius: 10;" />
+								<Label text="ћ" />
+								<Button fx:id="acceptFromAccountButton" mnemonicParsing="false" prefWidth="150.0" style="-fx-background-color: #0B9DFD; -fx-border-color: #0b9bfd; -fx-text-fill: white; -fx-border-radius: 10; -fx-background-radius: 10;" text="ACCEPT" textAlignment="CENTER" />
 							</HBox>
-							<Label fx:id="errorInvalidFromAccount" style="-fx-text-fill: red;"
-								   text="Cannot parse the account ID" visible="false"/>
+							<Label fx:id="errorInvalidFromAccount" style="-fx-text-fill: red;" text="Cannot parse the account ID" visible="false" />
 
 						</VBox>
-						<VBox fx:id="toAccountsVBox" maxHeight="1.7976931348623157E308" spacing="10.0">
-							<Label text="To account(s)"/>
-							<TableView fx:id="toTransferTable" focusTraversable="false" maxHeight="-Infinity"
-									   maxWidth="-Infinity"/>
-							<HBox fx:id="toHBox" alignment="CENTER_LEFT" maxHeight="-Infinity" maxWidth="-Infinity"
-								  spacing="20.0">
-								<TextField fx:id="transferToAccountIDTextField" alignment="CENTER" promptText="X.X.XXXX"
-										   style="-fx-background-radius: 10; -fx-border-radius: 10;"/>
-								<TextField fx:id="transferToAmountTextField" layoutX="10.0" layoutY="10.0"
-										   style="-fx-background-radius: 10; -fx-border-radius: 10;"/>
-								<Label text="ћ"/>
-								<Button fx:id="acceptToAccountButton" mnemonicParsing="false" prefWidth="150.0"
-										style="-fx-background-color: #0B9DFD; -fx-border-color: #0b9bfd; -fx-text-fill: white; -fx-border-radius: 10; -fx-background-radius: 10;"
-										text="ACCEPT" textAlignment="CENTER"/>
+						<VBox fx:id="toAccountsVBox" alignment="TOP_CENTER" maxHeight="1.7976931348623157E308" spacing="10.0">
+							<Label text="To account(s)" />
+							<TableView fx:id="toTransferTable" focusTraversable="false" maxHeight="-Infinity" maxWidth="-Infinity" />
+							<HBox fx:id="toHBox" alignment="CENTER_LEFT" maxHeight="-Infinity" maxWidth="-Infinity" spacing="20.0">
+								<TextField fx:id="transferToAccountIDTextField" alignment="CENTER" promptText="X.X.XXXX" style="-fx-background-radius: 10; -fx-border-radius: 10;" />
+								<TextField fx:id="transferToAmountTextField" layoutX="10.0" layoutY="10.0" style="-fx-background-radius: 10; -fx-border-radius: 10;" />
+								<Label text="ћ" />
+								<Button fx:id="acceptToAccountButton" mnemonicParsing="false" prefWidth="150.0" style="-fx-background-color: #0B9DFD; -fx-border-color: #0b9bfd; -fx-text-fill: white; -fx-border-radius: 10; -fx-background-radius: 10;" text="ACCEPT" textAlignment="CENTER" />
 							</HBox>
-							<Label fx:id="errorInvalidToAccount" style="-fx-text-fill: red;"
-								   text="Cannot parse the account ID" visible="false"/>
+							<Label fx:id="errorInvalidToAccount" style="-fx-text-fill: red;" text="Cannot parse the account ID" visible="false" />
 						</VBox>
 						<HBox>
-							<Label fx:id="invalidTransferList"
-								   text=" There must be at least one recipient and one sender for the transfer "
-								   textFill="RED" visible="false"/>
-							<Region HBox.hgrow="ALWAYS"/>
-							<Label fx:id="invalidTransferTotal" text=" Total debits must equal total credits "
-								   textFill="RED" visible="false"/>
-							<Label fx:id="totalTransferLabel" text="0"/>
+							<Label fx:id="invalidTransferList" text=" There must be at least one recipient and one sender for the transfer " textFill="RED" visible="false" />
+							<Region HBox.hgrow="ALWAYS" />
+							<Label fx:id="invalidTransferTotal" text=" Total debits must equal total credits " textFill="RED" visible="false" />
+							<Label fx:id="totalTransferLabel" text="0" />
 						</HBox>
 					</VBox>
 				</VBox>
 				<VBox fx:id="systemDeleteUndeleteVBox" spacing="20.0" style="-fx-background-color: white;">
 					<padding>
-						<Insets left="15.0" right="15.0" top="10.0"/>
+						<Insets left="15.0" right="15.0" top="10.0" />
 					</padding>
 					<VBox spacing="10.0">
-						<Label fx:id="entityLabel" text="File ID"/>
+						<Label fx:id="entityLabel" text="File ID" />
 						<HBox alignment="CENTER_LEFT" spacing="20.0">
-							<TextField fx:id="entityID" alignment="CENTER" maxWidth="-Infinity" minWidth="300.0"
-									   promptText="X.X.XXXX" style="-fx-border-radius: 10; -fx-background-radius: 10;"/>
-							<ImageView fitHeight="15.0" fitWidth="15.0" pickOnBounds="true" preserveRatio="true"
-									   visible="false">
-								<Image url="@../../../../../icons/greencheck.png"/>
+							<TextField fx:id="entityID" alignment="CENTER" maxWidth="-Infinity" minWidth="300.0" promptText="X.X.XXXX" style="-fx-border-radius: 10; -fx-background-radius: 10;" />
+							<ImageView fitHeight="15.0" fitWidth="15.0" pickOnBounds="true" preserveRatio="true" visible="false">
+								<Image url="@../../../../../icons/greencheck.png" />
 							</ImageView>
-							<Label fx:id="invalidEntity" text="Cannot recognize entity ID" textFill="RED"
-								   visible="false"/>
+							<Label fx:id="invalidEntity" text="Cannot recognize entity ID" textFill="RED" visible="false" />
 						</HBox>
 					</VBox>
 					<VBox fx:id="systemExpirationVBox" disable="true" spacing="10.0">
-						<Label fx:id="expirationLabel" text="File will expire on:"/>
+						<Label fx:id="expirationLabel" text="File will expire on:" />
 						<HBox alignment="CENTER_LEFT" spacing="20.0" VBox.vgrow="ALWAYS">
-							<DatePicker fx:id="datePickerSystem"/>
-							<Label text="at"/>
+							<DatePicker fx:id="datePickerSystem" />
+							<Label text="at" />
 							<HBox alignment="CENTER_LEFT" spacing="5.0">
-								<TextField fx:id="hourFieldSystem" alignment="CENTER" maxWidth="50.0" minWidth="50.0"
-										   prefWidth="50.0" style="-fx-border-radius: 5; -fx-background-radius: 5;"
-										   text="00"/>
-								<Label text=":"/>
-								<TextField fx:id="minuteFieldSystem" alignment="CENTER" maxWidth="50.0" minWidth="50.0"
-										   prefWidth="50.0" style="-fx-border-radius: 5; -fx-background-radius: 5;"
-										   text="00"/>
-								<Label layoutX="65.0" layoutY="15.0" text=":"/>
-								<TextField fx:id="secondsFieldSystem" alignment="CENTER" layoutX="74.0" layoutY="10.0"
-										   maxWidth="50.0" minWidth="50.0" prefWidth="50.0"
-										   style="-fx-border-radius: 5; -fx-background-radius: 5;" text="00"/>
-								<HBox fx:id="timeZoneSystemHBox"/>
+								<TextField fx:id="hourFieldSystem" alignment="CENTER" maxWidth="50.0" minWidth="50.0" prefWidth="50.0" style="-fx-border-radius: 5; -fx-background-radius: 5;" text="00" />
+								<Label text=":" />
+								<TextField fx:id="minuteFieldSystem" alignment="CENTER" maxWidth="50.0" minWidth="50.0" prefWidth="50.0" style="-fx-border-radius: 5; -fx-background-radius: 5;" text="00" />
+								<Label layoutX="65.0" layoutY="15.0" text=":" />
+								<TextField fx:id="secondsFieldSystem" alignment="CENTER" layoutX="74.0" layoutY="10.0" maxWidth="50.0" minWidth="50.0" prefWidth="50.0" style="-fx-border-radius: 5; -fx-background-radius: 5;" text="00" />
+								<HBox fx:id="timeZoneSystemHBox" />
 							</HBox>
-							<Label fx:id="invalidExpirationDate" text="Invalid expiration date" textFill="RED"
-								   visible="false"/>
+							<Label fx:id="invalidExpirationDate" text="Invalid expiration date" textFill="RED" visible="false" />
 						</HBox>
-						<Label fx:id="systemCreateLocalTimeLabel"/>
+						<Label fx:id="systemCreateLocalTimeLabel" />
 					</VBox>
 				</VBox>
-				<VBox fx:id="fileContentsUpdateVBox" layoutX="11.0" layoutY="2970.0" spacing="20.0"
-					  style="-fx-background-color: white;">
+				<VBox fx:id="fileContentsUpdateVBox" layoutX="11.0" layoutY="2970.0" spacing="20.0" style="-fx-background-color: white;">
 					<padding>
-						<Insets left="15.0" right="15.0" top="10.0"/>
+						<Insets left="15.0" right="15.0" top="10.0" />
 					</padding>
 					<VBox layoutX="25.0" layoutY="20.0" spacing="10.0">
-						<Label text="Contents file"/>
+						<Label text="Contents file" />
 						<HBox alignment="CENTER_LEFT" spacing="20.0">
 							<VBox minWidth="600.0">
-								<TextField fx:id="contentsTextField" maxWidth="600.0" minWidth="600.0" prefWidth="600.0"
-										   style="-fx-border-radius: 10; -fx-background-radius: 10;"/>
-								<Label fx:id="contentsFilePathError" text="The file selected does not exist"
-									   textFill="RED" visible="false"/>
-								<Hyperlink fx:id="contentsLink" text="Hyperlink" visible="false"/>
+								<TextField fx:id="contentsTextField" maxWidth="600.0" minWidth="600.0" prefWidth="600.0" style="-fx-border-radius: 10; -fx-background-radius: 10;" />
+								<Label fx:id="contentsFilePathError" text="The file selected does not exist" textFill="RED" visible="false" />
+								<Hyperlink fx:id="contentsLink" text="Hyperlink" visible="false" />
 							</VBox>
-							<Button fx:id="browseContentsButton" mnemonicParsing="false"
-									onAction="#browseToContentsFile" prefWidth="150.0"
-									style="-fx-background-color: #0b9bfd; -fx-border-color: #0b9bfd; -fx-background-radius: 10; -fx-border-radius: 10; -fx-text-fill: white;"
-									text="BROWSE"/>
+							<Button fx:id="browseContentsButton" mnemonicParsing="false" onAction="#browseToContentsFile" prefWidth="150.0" style="-fx-background-color: #0b9bfd; -fx-border-color: #0b9bfd; -fx-background-radius: 10; -fx-border-radius: 10; -fx-text-fill: white;" text="BROWSE" />
 						</HBox>
 						<HBox fx:id="shaTextFlow" spacing="2.0">
-							<Label text="SHA-384 Checksum: " wrapText="true"/>
-							<Text fx:id="fileDigest"/>
+							<Label text="SHA-384 Checksum: " wrapText="true" />
+							<Text fx:id="fileDigest" />
 						</HBox>
 					</VBox>
-					<VBox layoutX="25.0" layoutY="163.0" spacing="10.0"/>
+					<VBox layoutX="25.0" layoutY="163.0" spacing="10.0" />
 					<VBox spacing="10.0">
-						<Label text="Chunk size"/>
+						<Label text="Chunk size" />
 						<HBox alignment="CENTER_LEFT" spacing="20.0">
-							<TextField fx:id="chunkSizeTextField" maxWidth="300.0" minWidth="300.0" prefWidth="300.0"
-									   style="-fx-border-radius: 10; -fx-background-radius: 10;" text="1024"/>
-							<Label text="bytes"/>
-							<ImageView fitHeight="15.0" fitWidth="15.0" pickOnBounds="true" preserveRatio="true"
-									   visible="false">
-								<Image url="@../../../../../icons/greencheck.png"/>
+							<TextField fx:id="chunkSizeTextField" maxWidth="300.0" minWidth="300.0" prefWidth="300.0" style="-fx-border-radius: 10; -fx-background-radius: 10;" text="1024" />
+							<Label text="bytes" />
+							<ImageView fitHeight="15.0" fitWidth="15.0" pickOnBounds="true" preserveRatio="true" visible="false">
+								<Image url="@../../../../../icons/greencheck.png" />
 							</ImageView>
-							<Label fx:id="invalidChunkSizeLabel" text="Invalid chunk size" textFill="RED"
-								   visible="false"/>
+							<Label fx:id="invalidChunkSizeLabel" text="Invalid chunk size" textFill="RED" visible="false" />
 						</HBox>
 					</VBox>
 					<VBox layoutX="25.0" layoutY="20.0" spacing="10.0">
-						<Label text="Interval between transactions"/>
+						<Label text="Interval between transactions" />
 						<HBox alignment="CENTER_LEFT" spacing="20.0">
-							<TextField fx:id="intervalTextField" maxWidth="300.0" minWidth="300.0" prefWidth="300.0"
-									   style="-fx-border-radius: 10; -fx-background-radius: 10;" text="100"/>
-							<Label text="nanoseconds"/>
-							<ImageView fitHeight="15.0" fitWidth="15.0" pickOnBounds="true" preserveRatio="true"
-									   visible="false">
-								<Image url="@../../../../../icons/greencheck.png"/>
+							<TextField fx:id="intervalTextField" maxWidth="300.0" minWidth="300.0" prefWidth="300.0" style="-fx-border-radius: 10; -fx-background-radius: 10;" text="100" />
+							<Label text="nanoseconds" />
+							<ImageView fitHeight="15.0" fitWidth="15.0" pickOnBounds="true" preserveRatio="true" visible="false">
+								<Image url="@../../../../../icons/greencheck.png" />
 							</ImageView>
-							<Label fx:id="invalidIntervalLabel" text="Invalid interval between transactions"
-								   textFill="RED" visible="false"/>
+							<Label fx:id="invalidIntervalLabel" text="Invalid interval between transactions" textFill="RED" visible="false" />
 						</HBox>
 					</VBox>
 				</VBox>
 				<VBox fx:id="freezeVBox" spacing="20.0" style="-fx-background-color: white;">
 					<VBox fx:id="freezeStartVBox" spacing="20.0">
-						<Label text="Freeze Start Time"/>
+						<Label text="Freeze Start Time" />
 						<HBox alignment="CENTER_LEFT" spacing="20.0">
-							<DatePicker fx:id="freezeDatePicker"/>
-							<Label minWidth="11.0" text="at"/>
+							<DatePicker fx:id="freezeDatePicker" />
+							<Label minWidth="11.0" text="at" />
 							<HBox alignment="CENTER_LEFT" spacing="5.0">
-								<TextField fx:id="freezeHourField" alignment="CENTER" maxWidth="50.0" minWidth="50.0"
-										   prefWidth="50.0" style="-fx-border-radius: 5; -fx-background-radius: 5;"
-										   text="01"/>
-								<Label text=":"/>
-								<TextField fx:id="freezeMinuteField" alignment="CENTER" maxWidth="50.0" minWidth="50.0"
-										   prefWidth="50.0" style="-fx-border-radius: 5; -fx-background-radius: 5;"
-										   text="00"/>
-								<Label layoutX="65.0" layoutY="15.0" text=":"/>
-								<TextField fx:id="freezeSecondsField" alignment="CENTER" layoutX="74.0" layoutY="10.0"
-										   maxWidth="50.0" minWidth="50.0" prefWidth="50.0"
-										   style="-fx-border-radius: 5; -fx-background-radius: 5;" text="00"/>
-								<Label layoutX="128.0" layoutY="16.0" text="."/>
-								<TextField fx:id="freezeNanosField" alignment="CENTER" layoutX="136.0" layoutY="11.0"
-										   minWidth="39.0" prefHeight="27.0" prefWidth="150.0"
-										   style="-fx-border-radius: 5; -fx-background-radius: 5;" text="000000000"/>
-								<HBox fx:id="freezeTimeZoneHBox"/>
+								<TextField fx:id="freezeHourField" alignment="CENTER" maxWidth="50.0" minWidth="50.0" prefWidth="50.0" style="-fx-border-radius: 5; -fx-background-radius: 5;" text="01" />
+								<Label text=":" />
+								<TextField fx:id="freezeMinuteField" alignment="CENTER" maxWidth="50.0" minWidth="50.0" prefWidth="50.0" style="-fx-border-radius: 5; -fx-background-radius: 5;" text="00" />
+								<Label layoutX="65.0" layoutY="15.0" text=":" />
+								<TextField fx:id="freezeSecondsField" alignment="CENTER" layoutX="74.0" layoutY="10.0" maxWidth="50.0" minWidth="50.0" prefWidth="50.0" style="-fx-border-radius: 5; -fx-background-radius: 5;" text="00" />
+								<Label layoutX="128.0" layoutY="16.0" text="." />
+								<TextField fx:id="freezeNanosField" alignment="CENTER" layoutX="136.0" layoutY="11.0" minWidth="39.0" prefHeight="27.0" prefWidth="150.0" style="-fx-border-radius: 5; -fx-background-radius: 5;" text="000000000" />
+								<HBox fx:id="freezeTimeZoneHBox" />
 							</HBox>
 						</HBox>
-						<Label fx:id="freezeUTCTimeLabel" visible="false"/>
-						<Label fx:id="freezeTimeErrorLabel" style="-fx-text-fill: RED;" text="Invalid freeze start time"
-							   visible="false"/>
+						<Label fx:id="freezeUTCTimeLabel" visible="false" />
+						<Label fx:id="freezeTimeErrorLabel" style="-fx-text-fill: RED;" text="Invalid freeze start time" visible="false" />
 					</VBox>
 					<VBox fx:id="freezeFileVBox" spacing="20.0">
-						<Label text="File ID"/>
+						<Label text="File ID" />
 						<HBox alignment="CENTER_LEFT" spacing="20.0">
-							<TextField fx:id="freezeFileIDTextField" alignment="CENTER" maxWidth="-Infinity"
-									   minWidth="300.0" promptText="X.X.XXXX"
-									   style="-fx-border-radius: 10; -fx-background-radius: 10;"/>
-							<Label fx:id="invalidFreezeFile" text="Cannot recognize file ID" textFill="RED"
-								   visible="false"/>
+							<TextField fx:id="freezeFileIDTextField" alignment="CENTER" maxWidth="-Infinity" minWidth="300.0" promptText="X.X.XXXX" style="-fx-border-radius: 10; -fx-background-radius: 10;" />
+							<Label fx:id="invalidFreezeFile" text="Cannot recognize file ID" textFill="RED" visible="false" />
 						</HBox>
-						<Label text="File Hash"/>
+						<Label text="File Hash" />
 						<VBox spacing="5.0">
-							<TextField fx:id="freezeFileHashTextField" maxWidth="-Infinity" minWidth="800.0"
-									   style="-fx-border-radius: 10; -fx-background-radius: 10;"/>
-							<Label fx:id="invalidFreezeFileHash" style="-fx-text-fill: red;"
-								   text="File hash cannot be parsed" visible="false"/>
+							<TextField fx:id="freezeFileHashTextField" maxWidth="-Infinity" minWidth="800.0" style="-fx-border-radius: 10; -fx-background-radius: 10;" />
+							<Label fx:id="invalidFreezeFileHash" style="-fx-text-fill: red;" text="File hash cannot be parsed" visible="false" />
 						</VBox>
 					</VBox>
 					<padding>
-						<Insets left="15.0" right="15.0" top="10.0"/>
+						<Insets left="15.0" right="15.0" top="10.0" />
 					</padding>
 				</VBox>
 				<HBox alignment="CENTER_RIGHT">
 					<padding>
-						<Insets right="15.0"/>
+						<Insets right="15.0" />
 					</padding>
-					<Button fx:id="resetFormButton" mnemonicParsing="false" onAction="#cleanForm" prefWidth="200.0"
-							style="-fx-background-color: white; -fx-border-color: #0b9bfd; -fx-text-fill: #0B9DFD; -fx-border-radius: 10; -fx-background-radius: 10;"
-							text="RESET FORM" textAlignment="CENTER"/>
+					<Button fx:id="resetFormButton" mnemonicParsing="false" onAction="#cleanForm" prefWidth="200.0" style="-fx-background-color: white; -fx-border-color: #0b9bfd; -fx-text-fill: #0B9DFD; -fx-border-radius: 10; -fx-background-radius: 10;" text="RESET FORM" textAlignment="CENTER" />
 				</HBox>
 				<padding>
-					<Insets top="15.0"/>
+					<Insets top="15.0" />
 				</padding>
 			</VBox>
 		</ScrollPane>
-		<TextField fx:id="keyLoadingField" maxHeight="1.0" minHeight="1.0" prefHeight="1.0"
-				   style="-fx-background-color: #0b9dfd;" visible="false"/>
+		<TextField fx:id="keyLoadingField" maxHeight="1.0" minHeight="1.0" prefHeight="1.0" style="-fx-background-color: #0b9dfd;" visible="false" />
 		<padding>
-			<Insets top="20.0"/>
+			<Insets top="20.0" />
 		</padding>
 	</VBox>
 </AnchorPane>

--- a/tools-ui/src/test/java/com/hedera/hashgraph/client/ui/CreatePaneControllerTest.java
+++ b/tools-ui/src/test/java/com/hedera/hashgraph/client/ui/CreatePaneControllerTest.java
@@ -163,6 +163,9 @@ public class CreatePaneControllerTest extends TestBase implements Supplier<TestB
 
 	private static final long THREAD_PAUSE_TIME = 1000;
 	public static final int TENTH_OF_A_SECOND = 100;
+	public static final int AUTO_RENEW_DEFAULT = 7000013;
+	public static final String CLOUD_OUTPUT_DIRECTORY =
+			"src/test/resources/Transactions - Documents/OutputFiles/test1.council2@hederacouncil.org";
 	private final String resources = new File("src/test/resources/Transactions - Documents/").getAbsolutePath().replace(
 			System.getProperty("user.home") + "/", "") + "/";
 	private static final String DEFAULT_STORAGE = System.getProperty(
@@ -197,10 +200,11 @@ public class CreatePaneControllerTest extends TestBase implements Supplier<TestB
 			}
 			properties = new UserAccessibleProperties(DEFAULT_STORAGE + "/Files/user.properties", "");
 
-			if (new File(currentRelativePath.toAbsolutePath() + "/src/test/resources/Transactions - " +
-					"Documents/OutputFiles/test1.council2@hederacouncil.org/").mkdirs()) {
+			if (new File(currentRelativePath.toAbsolutePath() + CLOUD_OUTPUT_DIRECTORY).mkdirs()) {
 				logger.info("Output path created");
 			}
+
+			FileUtils.cleanDirectory(new File(CLOUD_OUTPUT_DIRECTORY));
 
 			remakeTransactionTools();
 
@@ -277,7 +281,7 @@ public class CreatePaneControllerTest extends TestBase implements Supplier<TestB
 			}
 
 			final var outputDirectory = new File(
-					"src/test/resources/Transactions - Documents/OutputFiles/test1.council2@hederacouncil.org");
+					CLOUD_OUTPUT_DIRECTORY);
 			FileUtils.cleanDirectory(outputDirectory);
 
 			TestUtil.copyCreatePaneKeys();
@@ -684,7 +688,7 @@ public class CreatePaneControllerTest extends TestBase implements Supplier<TestB
 
 
 		var transactions = new File(
-				"src/test/resources/Transactions - Documents/OutputFiles/test1.council2@hederacouncil.org").listFiles(
+				CLOUD_OUTPUT_DIRECTORY).listFiles(
 				pathname -> {
 					var name = pathname.getName();
 					return name.endsWith(Constants.TRANSACTION_EXTENSION) || name.endsWith(Constants.TXT_EXTENSION);
@@ -793,7 +797,7 @@ public class CreatePaneControllerTest extends TestBase implements Supplier<TestB
 		createPanePage.createAndExport(resources);
 
 		var transactions = new File(
-				"src/test/resources/Transactions - Documents/OutputFiles/test1.council2@hederacouncil.org").listFiles(
+				CLOUD_OUTPUT_DIRECTORY).listFiles(
 				pathname -> {
 					var name = pathname.getName();
 					return name.endsWith(Constants.TRANSACTION_EXTENSION) || name.endsWith(Constants.TXT_EXTENSION);
@@ -909,7 +913,7 @@ public class CreatePaneControllerTest extends TestBase implements Supplier<TestB
 		createPanePage.createAndExport(resources);
 
 		var transactions = new File(
-				"src/test/resources/Transactions - Documents/OutputFiles/test1.council2@hederacouncil.org").listFiles(
+				CLOUD_OUTPUT_DIRECTORY).listFiles(
 				pathname -> {
 					var name = pathname.getName();
 					return name.endsWith(Constants.TRANSACTION_EXTENSION) || name.endsWith(Constants.TXT_EXTENSION);
@@ -946,7 +950,96 @@ public class CreatePaneControllerTest extends TestBase implements Supplier<TestB
 		assertEquals("A memo", toolTransaction.getMemo());
 
 		assertTrue(toolTransaction.getTransaction() instanceof AccountUpdateTransaction);
-		assertNotNull(((AccountUpdateTransaction) toolTransaction.getTransaction()).getKey());
+		final var accountUpdateTransaction = (AccountUpdateTransaction) toolTransaction.getTransaction();
+		assertNotNull(accountUpdateTransaction.getKey());
+		assertNull(accountUpdateTransaction.getAutoRenewPeriod());
+
+		assertTrue(comment.has("Author"));
+		assertEquals("test1.council2@hederacouncil.org", comment.get("Author").getAsString());
+		assertTrue(comment.has("Contents"));
+		assertEquals("this is a comment that will go with the update transaction",
+				comment.get("Contents").getAsString());
+		assertTrue(comment.has("Timestamp"));
+	}
+
+	@Test
+	public void createAccountUpdateAutoRenew_test() throws HederaClientException {
+		final var date = DateUtils.addDays(new Date(), 2);
+		final var datePickerFormat = new SimpleDateFormat("MM/dd/yyyy");
+		datePickerFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+		final var sdf = new SimpleDateFormat("yyyy-MM-dd");
+		sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
+		find(CREATE_LOCAL_TIME_LABEL);
+
+
+		final var dtf = DateTimeFormatter.ofPattern("MM/dd/yyyy");
+		final var localDateTime = LocalDateTime.of(LocalDate.parse(datePickerFormat.format(date), dtf),
+				LocalTime.of(2, 30, 45));
+
+		final var transactionValidStart = Date.from(localDateTime.atZone(ZoneId.systemDefault()).toInstant());
+
+
+		createPanePage.selectTransaction(CreateTransactionType.UPDATE.getTypeString())
+				.setComment("this is a comment that will go with the update transaction")
+				.setUpdateAccount(73);
+
+		createPanePage.setDate(datePickerFormat.format(date))
+				.setHours(2)
+				.setMinutes(30)
+				.setSeconds(45)
+				.setMemo("A memo")
+				.setFeePayerAccount(1059)
+				.setNodeAccount(42)
+				.setAutoRenew(AUTO_RENEW_DEFAULT);
+
+		assertTrue(find(CREATE_CHOICE_BOX).isVisible());
+		logger.info("Exporting to \"{}\"", resources);
+		createPanePage.createAndExport(resources);
+
+
+
+		final var transactions = new File(
+				CLOUD_OUTPUT_DIRECTORY).listFiles(
+				pathname -> {
+					final var name = pathname.getName();
+					return name.endsWith(Constants.TRANSACTION_EXTENSION) || name.endsWith(Constants.TXT_EXTENSION);
+				});
+
+		assert transactions != null;
+
+		ToolCryptoUpdateTransaction toolTransaction = null;
+		var comment = new JsonObject();
+
+		for (final var f : transactions) {
+			if (f.getName().contains("1059")) {
+				if (f.getName().endsWith(Constants.TRANSACTION_EXTENSION)) {
+					toolTransaction = new ToolCryptoUpdateTransaction(f);
+				}
+				if (f.getName().endsWith(Constants.TXT_EXTENSION)) {
+					comment = readJsonObject(f.getAbsolutePath());
+				}
+			}
+		}
+
+		assertNotNull(toolTransaction);
+
+		assertEquals(new Identifier(0, 0, 42), toolTransaction.getNodeID());
+		assertEquals("A memo", toolTransaction.getMemo());
+
+		assertTrue(toolTransaction.getTransaction() instanceof AccountUpdateTransaction);
+
+		assertEquals(new Identifier(0, 0, 1059).asAccount(),
+				toolTransaction.getTransactionId().accountId);
+
+		assertEquals(transactionValidStart.getTime() / 1000,
+				Objects.requireNonNull(toolTransaction.getTransactionId().validStart).getEpochSecond());
+		assertEquals("A memo", toolTransaction.getMemo());
+
+		assertTrue(toolTransaction.getTransaction() instanceof AccountUpdateTransaction);
+		final var accountUpdateTransaction = (AccountUpdateTransaction) toolTransaction.getTransaction();
+		assertNull(accountUpdateTransaction.getKey());
+		assertNotNull(accountUpdateTransaction.getAutoRenewPeriod());
+		assertEquals(AUTO_RENEW_DEFAULT, accountUpdateTransaction.getAutoRenewPeriod().getSeconds());
 
 		assertTrue(comment.has("Author"));
 		assertEquals("test1.council2@hederacouncil.org", comment.get("Author").getAsString());
@@ -990,7 +1083,7 @@ public class CreatePaneControllerTest extends TestBase implements Supplier<TestB
 		createPanePage.createAndExport(resources);
 
 		var transactions = new File(
-				"src/test/resources/Transactions - Documents/OutputFiles/test1.council2@hederacouncil.org").listFiles(
+				CLOUD_OUTPUT_DIRECTORY).listFiles(
 				pathname -> {
 					var name = pathname.getName();
 					return name.endsWith(Constants.LARGE_BINARY_EXTENSION) || name.endsWith(Constants.TXT_EXTENSION);
@@ -1069,7 +1162,7 @@ public class CreatePaneControllerTest extends TestBase implements Supplier<TestB
 
 		FileUtils.deleteDirectory(new File("src/test/resources/unzipped"));
 		FileUtils.cleanDirectory(
-				new File("src/test/resources/Transactions - Documents/OutputFiles/test1.council2@hederacouncil.org"));
+				new File(CLOUD_OUTPUT_DIRECTORY));
 	}
 
 	@Test
@@ -1122,7 +1215,7 @@ public class CreatePaneControllerTest extends TestBase implements Supplier<TestB
 
 
 		var transactions = new File(
-				"src/test/resources/Transactions - Documents/OutputFiles/test1.council2@hederacouncil.org").listFiles(
+				CLOUD_OUTPUT_DIRECTORY).listFiles(
 				pathname -> {
 					var name = pathname.getName();
 					return name.endsWith(Constants.TRANSACTION_EXTENSION) || name.endsWith(Constants.TXT_EXTENSION);
@@ -1192,7 +1285,7 @@ public class CreatePaneControllerTest extends TestBase implements Supplier<TestB
 
 
 		var transactions = new File(
-				"src/test/resources/Transactions - Documents/OutputFiles/test1.council2@hederacouncil.org").listFiles(
+				CLOUD_OUTPUT_DIRECTORY).listFiles(
 				pathname -> {
 					var name = pathname.getName();
 					return name.endsWith(Constants.TRANSACTION_EXTENSION) || name.endsWith(Constants.TXT_EXTENSION);
@@ -1244,7 +1337,7 @@ public class CreatePaneControllerTest extends TestBase implements Supplier<TestB
 		var expiration = LocalDateTime.now().plusMinutes(5);
 
 		final var outputDirectory = new File(
-				"src/test/resources/Transactions - Documents/OutputFiles/test1.council2@hederacouncil.org");
+				CLOUD_OUTPUT_DIRECTORY);
 
 		createPanePage.selectTransaction(CreateTransactionType.SYSTEM.getTypeString())
 				.setComment("this is a comment that will go with the system transaction - Contract Delete")
@@ -1310,7 +1403,7 @@ public class CreatePaneControllerTest extends TestBase implements Supplier<TestB
 
 
 		var transactions = new File(
-				"src/test/resources/Transactions - Documents/OutputFiles/test1.council2@hederacouncil.org").listFiles(
+				CLOUD_OUTPUT_DIRECTORY).listFiles(
 				pathname -> {
 					var name = pathname.getName();
 					return name.endsWith(Constants.TRANSACTION_EXTENSION) || name.endsWith(Constants.TXT_EXTENSION);
@@ -1378,7 +1471,7 @@ public class CreatePaneControllerTest extends TestBase implements Supplier<TestB
 
 
 		var transactions = new File(
-				"src/test/resources/Transactions - Documents/OutputFiles/test1.council2@hederacouncil.org").listFiles(
+				CLOUD_OUTPUT_DIRECTORY).listFiles(
 				pathname -> {
 					var name = pathname.getName();
 					return name.endsWith(Constants.TRANSACTION_EXTENSION) || name.endsWith(Constants.TXT_EXTENSION);
@@ -1883,7 +1976,7 @@ public class CreatePaneControllerTest extends TestBase implements Supplier<TestB
 				.clickOnPopupButton("CONTINUE");
 
 		var transactions = new File(
-				"src/test/resources/Transactions - Documents/OutputFiles/test1.council2@hederacouncil.org").listFiles(
+				CLOUD_OUTPUT_DIRECTORY).listFiles(
 				(dir, name) -> FilenameUtils.getExtension(name).equals(TRANSACTION_EXTENSION));
 
 		assert transactions != null;
@@ -1922,7 +2015,7 @@ public class CreatePaneControllerTest extends TestBase implements Supplier<TestB
 				.clickOnPopupButton("CONTINUE");
 
 		var transactions = new File(
-				"src/test/resources/Transactions - Documents/OutputFiles/test1.council2@hederacouncil.org").listFiles(
+				CLOUD_OUTPUT_DIRECTORY).listFiles(
 				(dir, name) -> FilenameUtils.getExtension(name).equals(TRANSACTION_EXTENSION));
 
 		assert transactions != null;
@@ -1969,7 +2062,7 @@ public class CreatePaneControllerTest extends TestBase implements Supplier<TestB
 				.clickOnPopupButton("CONTINUE");
 
 		var transactions = new File(
-				"src/test/resources/Transactions - Documents/OutputFiles/test1.council2@hederacouncil.org").listFiles(
+				CLOUD_OUTPUT_DIRECTORY).listFiles(
 				(dir, name) -> FilenameUtils.getExtension(name).equals(TRANSACTION_EXTENSION));
 
 		assert transactions != null;
@@ -2015,7 +2108,7 @@ public class CreatePaneControllerTest extends TestBase implements Supplier<TestB
 				.createAndExport(resources);
 
 		var transactions = new File(
-				"src/test/resources/Transactions - Documents/OutputFiles/test1.council2@hederacouncil.org").listFiles(
+				CLOUD_OUTPUT_DIRECTORY).listFiles(
 				(dir, name) -> FilenameUtils.getExtension(name).equals(TRANSACTION_EXTENSION));
 
 		assert transactions != null;
@@ -2042,7 +2135,7 @@ public class CreatePaneControllerTest extends TestBase implements Supplier<TestB
 			properties.resetProperties();
 			properties.setSetupPhase(SetupPhase.INITIAL_SETUP_PHASE);
 			var transactions = new File(
-					"src/test/resources/Transactions - Documents/OutputFiles/test1.council2@hederacouncil.org").listFiles(
+					CLOUD_OUTPUT_DIRECTORY).listFiles(
 					pathname -> {
 						var name = pathname.getName();
 						return name.endsWith(Constants.TXT_EXTENSION) ||

--- a/tools-ui/src/test/java/com/hedera/hashgraph/client/ui/InitialStartupPaneControllerTest.java
+++ b/tools-ui/src/test/java/com/hedera/hashgraph/client/ui/InitialStartupPaneControllerTest.java
@@ -31,8 +31,10 @@ import com.hedera.hashgraph.client.core.exceptions.HederaClientException;
 import com.hedera.hashgraph.client.core.props.UserAccessibleProperties;
 import com.hedera.hashgraph.client.core.security.SecurityUtilities;
 import com.hedera.hashgraph.client.ui.pages.InitialStartupPage;
+import com.hedera.hashgraph.client.ui.pages.TestUtil;
 import com.hedera.hashgraph.sdk.Mnemonic;
 import javafx.scene.Node;
+import javafx.scene.control.Label;
 import javafx.scene.control.TextField;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.MouseButton;
@@ -53,6 +55,7 @@ import java.awt.datatransfer.StringSelection;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Paths;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeoutException;
@@ -73,6 +76,7 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -218,7 +222,12 @@ public class InitialStartupPaneControllerTest extends TestBase implements Generi
 		logger.info("The words in the grid correspond to the words generated");
 
 		initialStartupPage.clickMnemonicPopupButton("OK")
-				.enterNewPasswordInPopup(PASSWORD);
+				.clickOnPopupButton("CANCEL");
+		final var nodes = TestUtil.getPopupNodes();
+		assertNotNull(nodes);
+		assertTrue(nodes.get(1) instanceof Label);
+		assertTrue(((Label) nodes.get(1)).getText().toLowerCase(Locale.ROOT).contains("please try again") );
+		initialStartupPage.enterNewPasswordInPopup(PASSWORD);
 
 
 		assertFalse(find(GENERATE_KEYS_BUTTON).isVisible());
@@ -231,16 +240,15 @@ public class InitialStartupPaneControllerTest extends TestBase implements Generi
 		assertTrue(find("FINISH").isVisible());
 		logger.info("Next step is visible");
 
-		var salt = getSalt(properties.getHash(), properties.isLegacy());
-		var mnemonic = getMnemonicFromFile(PASSWORD.toCharArray(), salt,
+		final var salt = getSalt(properties.getHash(), properties.isLegacy());
+		final var mnemonic = getMnemonicFromFile(PASSWORD.toCharArray(), salt,
 				properties.getPreferredStorageDirectory() + File.separator + MNEMONIC_PATH);
 
-		var storedWords = mnemonic.toString();
+		final var storedWords = mnemonic.toString();
 
 		assertEquals(storedWords.concat(" ").toLowerCase(), words.toLowerCase());
 		logger.info("The stored mnemonic is the same as the words displayed: Mnemonic can be decrypted using password");
 	}
-
 
 	@Test
 	public void generatePassphraseFromProvidedWords_Text() {
@@ -540,7 +548,6 @@ public class InitialStartupPaneControllerTest extends TestBase implements Generi
 			deleteDummyDrive(i);
 		}
 	}
-
 
 	@Test
 	public void passwordPolicy_test() {

--- a/tools-ui/src/test/java/com/hedera/hashgraph/client/ui/TestBase.java
+++ b/tools-ui/src/test/java/com/hedera/hashgraph/client/ui/TestBase.java
@@ -54,7 +54,7 @@ public class TestBase extends ApplicationTest {
 	@BeforeClass
 	public static void setupHeadlessMode() {
 		//Comment this line while testing on local system. All tests on circle ci should run headless.
-		//System.setProperty("headless", "true");
+		System.setProperty("headless", "true");
 
 		if (Boolean.getBoolean("headless")) {
 			System.setProperty("testfx.robot", "glass");

--- a/tools-ui/src/test/java/com/hedera/hashgraph/client/ui/TestBase.java
+++ b/tools-ui/src/test/java/com/hedera/hashgraph/client/ui/TestBase.java
@@ -54,7 +54,7 @@ public class TestBase extends ApplicationTest {
 	@BeforeClass
 	public static void setupHeadlessMode() {
 		//Comment this line while testing on local system. All tests on circle ci should run headless.
-		System.setProperty("headless", "true");
+		//System.setProperty("headless", "true");
 
 		if (Boolean.getBoolean("headless")) {
 			System.setProperty("testfx.robot", "glass");

--- a/tools-ui/src/test/java/com/hedera/hashgraph/client/ui/pages/CreatePanePage.java
+++ b/tools-ui/src/test/java/com/hedera/hashgraph/client/ui/pages/CreatePanePage.java
@@ -740,6 +740,13 @@ public class CreatePanePage {
 		return this;
 	}
 
+	public CreatePanePage setAutoRenew(final long seconds) {
+		driver.ensureVisible(driver.find("#updateAutoRenew"));
+		driver.doubleClickOn("#updateAutoRenew");
+		driver.write(String.valueOf(seconds));
+		return this;
+	}
+
 
 	public enum OperationType {
 		delete, undelete

--- a/tools-ui/src/test/java/com/hedera/hashgraph/client/ui/pages/InitialStartupPage.java
+++ b/tools-ui/src/test/java/com/hedera/hashgraph/client/ui/pages/InitialStartupPage.java
@@ -298,6 +298,12 @@ public class InitialStartupPage {
 		return this;
 	}
 
+	public InitialStartupPage clickOnPopupButton(final String text) {
+		final var continueButton = findButtonInPopup(Objects.requireNonNull(getPopupNodes()), text);
+		driver.clickOn(continueButton);
+		return this;
+	}
+
 	public void typePassword(String s, PasswordField field) {
 		field.setText(s);
 		driver.clickOn(field);
@@ -325,5 +331,6 @@ public class InitialStartupPage {
 		}
 		return passwordFields;
 	}
+
 
 }


### PR DESCRIPTION
**Description**:
- Fixed an issue where nicknames were not entered in the Transfer Transaction tables (#200)
- Fixed an issue where it was possible to cancel entering a password when creating the Recovery Phrase (#197)
- Fixed an issue where the input json used for creating update transactions would always include the Auto Renew Duration Field (#205)

**Related issue(s)**:

closes #197 
closes #200 
closes #205

**Notes for reviewer**:
This is a cumulative patch to an existing release. 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
