### PR TITLE
fix(#249):  fix bundle not showing in history if it contains account files that are named differently than their name in accounts folder

### DIFF
--- a/tools-core/src/main/java/com/hedera/hashgraph/client/core/remote/BundleFile.java
+++ b/tools-core/src/main/java/com/hedera/hashgraph/client/core/remote/BundleFile.java
@@ -340,7 +340,6 @@ public class BundleFile extends RemoteFile implements GenericFileReadWriteAware 
 		private final String nickname;
 		private final Identifier id;
 		private final String oldNickname;
-		private final boolean duplicate;
 
 		public InfoKey(final File file) throws HederaClientException, InvalidProtocolBufferException {
 			final var info = AccountInfo.fromBytes(readBytes(file));
@@ -353,9 +352,6 @@ public class BundleFile extends RemoteFile implements GenericFileReadWriteAware 
 			this.oldNickname =
 					existingInfosMap.getOrDefault(info.accountId, "");
 
-			this.duplicate = oldNickname.equals(nickname) && Arrays.equals(info.toBytes(),
-					readBytes(new File(ACCOUNTS_INFO_FOLDER, file.getName())));
-
 		}
 
 		public String getNickname() {
@@ -364,10 +360,6 @@ public class BundleFile extends RemoteFile implements GenericFileReadWriteAware 
 
 		public Identifier getId() {
 			return id;
-		}
-
-		public boolean isDuplicate() {
-			return duplicate;
 		}
 
 		@Override

--- a/tools-ui/src/test/java/com/hedera/hashgraph/client/ui/HomePaneSupplementalTest.java
+++ b/tools-ui/src/test/java/com/hedera/hashgraph/client/ui/HomePaneSupplementalTest.java
@@ -55,6 +55,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static com.hedera.hashgraph.client.core.constants.Messages.BUNDLE_TITLE_MESSAGE_FORMAT;
+import static com.hedera.hashgraph.client.ui.JavaFXIDs.HISTORY_FILES_VBOX;
 import static com.hedera.hashgraph.client.ui.JavaFXIDs.NEW_FILES_VBOX;
 import static junit.framework.TestCase.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -391,6 +392,21 @@ public class HomePaneSupplementalTest extends TestBase implements GenericFileRea
 		assertTrue(finalKeys.contains("KeyStore-1.pub"));
 		assertTrue(finalKeys.contains("KeyStore-2.pub"));
 		assertTrue(finalKeys.contains("KeyStore-3.pub"));
+
+		// test that the bundle exists in history
+
+		var nodes = lookup(HISTORY_FILES_VBOX).lookup(".label").queryAll();
+
+		var labels = new ArrayList<String>();
+		for (var node : nodes) {
+			if (node instanceof Label) {
+				labels.add(((Label) node).getText());
+			}
+		}
+
+		assertTrue(labels.stream().anyMatch(f -> f.contains("AccountOne")));
+		assertTrue(labels.stream().anyMatch(f -> f.contains("Treasury test")));
+
 	}
 
 	@Test


### PR DESCRIPTION
**Description**:

 fix bundle not showing in history in it contains account files that are named differently than their name in accounts folder

**Related issue(s)**:

Fixes #249

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
