### PR TITLE
Fix for missing null check

### DIFF
--- a/tools-ui/src/main/java/com/hedera/hashgraph/client/ui/HomePaneController.java
+++ b/tools-ui/src/main/java/com/hedera/hashgraph/client/ui/HomePaneController.java
@@ -79,27 +79,28 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
-import static com.hedera.hashgraph.client.core.constants.Constants.*;
 import static com.hedera.hashgraph.client.core.constants.Constants.DEFAULT_ACCOUNTS;
 import static com.hedera.hashgraph.client.core.constants.Constants.DEFAULT_STORAGE;
 import static com.hedera.hashgraph.client.core.constants.Constants.FONT_SIZE;
 import static com.hedera.hashgraph.client.core.constants.Constants.GPG_EXTENSION;
+import static com.hedera.hashgraph.client.core.constants.Constants.INPUT_FILES;
 import static com.hedera.hashgraph.client.core.constants.Constants.JSON_EXTENSION;
 import static com.hedera.hashgraph.client.core.constants.Constants.KEYS_COLUMNS;
 import static com.hedera.hashgraph.client.core.constants.Constants.KEYS_FOLDER;
+import static com.hedera.hashgraph.client.core.constants.Constants.OUTPUT_FILES;
 import static com.hedera.hashgraph.client.core.constants.Constants.PUBLIC_KEY_LOCATION;
 import static com.hedera.hashgraph.client.core.constants.Constants.PUB_EXTENSION;
 import static com.hedera.hashgraph.client.core.enums.Actions.ACCEPT;
 import static com.hedera.hashgraph.client.core.enums.Actions.DECLINE;
-import static com.hedera.hashgraph.client.ui.utilities.Utilities.*;
+import static com.hedera.hashgraph.client.ui.utilities.Utilities.checkBoxListener;
 
 
 @SuppressWarnings({ "ResultOfMethodCallIgnored" })
 public class HomePaneController implements GenericFileReadWriteAware {
 
 	private static final Logger logger = LogManager.getLogger(HomePaneController.class);
-	public static final double VBOX_SPACING = 20;
-
+	private static final double VBOX_SPACING = 20;
+	private static boolean badDrive = false;
 
 	// region FXML
 	public VBox defaultViewVBox;
@@ -180,7 +181,17 @@ public class HomePaneController implements GenericFileReadWriteAware {
 		var count = 0;
 		final var outs = controller.getOneDriveCredentials();
 		for (final var inputLocation : outs.keySet()) {
-			count += Objects.requireNonNull(new File(inputLocation, INPUT_FILES).listFiles()).length;
+			final var filelist = new File(inputLocation, INPUT_FILES).listFiles();
+			if (filelist == null) {
+				if (!badDrive) {
+					badDrive = true;
+					Platform.runLater(() -> PopupMessage.display("Error reading files", String.format(
+							"The application was unable to read files from the remote location: %s. Please make sure " +
+									"that the application is able to read the drive.", inputLocation)));
+				}
+				continue;
+			}
+			count += Objects.requireNonNull(filelist).length;
 		}
 		return count;
 	}

--- a/tools-ui/src/test/java/com/hedera/hashgraph/client/ui/TestBase.java
+++ b/tools-ui/src/test/java/com/hedera/hashgraph/client/ui/TestBase.java
@@ -54,7 +54,7 @@ public class TestBase extends ApplicationTest {
 	@BeforeClass
 	public static void setupHeadlessMode() {
 		//Comment this line while testing on local system. All tests on circle ci should run headless.
-		//System.setProperty("headless", "true");
+		System.setProperty("headless", "true");
 
 		if (Boolean.getBoolean("headless")) {
 			System.setProperty("testfx.robot", "glass");

--- a/tools-ui/src/test/java/com/hedera/hashgraph/client/ui/TestBase.java
+++ b/tools-ui/src/test/java/com/hedera/hashgraph/client/ui/TestBase.java
@@ -54,7 +54,7 @@ public class TestBase extends ApplicationTest {
 	@BeforeClass
 	public static void setupHeadlessMode() {
 		//Comment this line while testing on local system. All tests on circle ci should run headless.
-		System.setProperty("headless", "true");
+		//System.setProperty("headless", "true");
 
 		if (Boolean.getBoolean("headless")) {
 			System.setProperty("testfx.robot", "glass");


### PR DESCRIPTION
Signed-off-by: David Sergio Matusevich <davidmatusevich@swirldslabs.com>

**Description**:
Fixed an issue, where a missing null check caused the app not to start if one of the Remote Folders is deleted or missing. This was not an issue caused by the MacOS update, but rather an issue with OneDrive not starting after the upgrade.

**Related issue(s)**:

Fixes #318 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
