### PR TITLE
fix(#391): don't validate staked node id against node account list, make it just a single number

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 	<groupId>com.hedera.hashgraph</groupId>
 	<artifactId>hedera-transaction-tool</artifactId>
 
-	<version>0.11.0-beta.3</version>
+	<version>0.11.0-beta.4</version>
 	<name>Hedera Transaction Tool</name>
 
 	<modules>

--- a/tools-bom/pom.xml
+++ b/tools-bom/pom.xml
@@ -28,7 +28,7 @@
 	<parent>
 		<groupId>com.hedera.hashgraph</groupId>
 		<artifactId>hedera-transaction-tool</artifactId>
-		<version>0.11.0-beta.3</version>
+		<version>0.11.0-beta.4</version>
 	</parent>
 
 	<!-- Project Identifier & Type -->

--- a/tools-cli/pom.xml
+++ b/tools-cli/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<artifactId>hedera-transaction-tool</artifactId>
 		<groupId>com.hedera.hashgraph</groupId>
-		<version>0.11.0-beta.3</version>
+		<version>0.11.0-beta.4</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -33,7 +33,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>tools-cli</artifactId>
-	<version>0.11.0-beta.3</version>
+	<version>0.11.0-beta.4</version>
 	<packaging>jar</packaging>
 
 	<dependencyManagement>
@@ -53,7 +53,7 @@
 		<dependency>
 			<groupId>com.hedera.hashgraph</groupId>
 			<artifactId>tools-core</artifactId>
-			<version>0.11.0-beta.3</version>
+			<version>0.11.0-beta.4</version>
 		</dependency>
 
 		<!-- Logging SLF4j + Log4j2 implementation -->

--- a/tools-core/pom.xml
+++ b/tools-core/pom.xml
@@ -25,14 +25,14 @@
 	<parent>
 		<artifactId>hedera-transaction-tool</artifactId>
 		<groupId>com.hedera.hashgraph</groupId>
-		<version>0.11.0-beta.3</version>
+		<version>0.11.0-beta.4</version>
 	</parent>
 
 	<!-- Maven Model Version -->
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>tools-core</artifactId>
-	<version>0.11.0-beta.3</version>
+	<version>0.11.0-beta.4</version>
 	<packaging>jar</packaging>
 
 	<dependencyManagement>

--- a/tools-core/src/main/java/com/hedera/hashgraph/client/core/remote/TransactionFile.java
+++ b/tools-core/src/main/java/com/hedera/hashgraph/client/core/remote/TransactionFile.java
@@ -370,7 +370,7 @@ public class TransactionFile extends RemoteFile implements GenericFileReadWriteA
 		label.setWrapText(true);
 		detailsGridPane.add(label, 0, count);
 		detailsGridPane.add(new Label(createTransaction.getStakedNodeId() == null ?	"" :
-				new Identifier(0, 0, createTransaction.getStakedNodeId()).toNicknameAndChecksum(nicknames)), 1, count++);
+				createTransaction.getStakedNodeId().toString()), 1, count++);
 
 		label = new Label("Decline Staking Rewards: ");
 		label.setWrapText(true);
@@ -444,8 +444,7 @@ public class TransactionFile extends RemoteFile implements GenericFileReadWriteA
 			var label = new Label("Staked Node ID: ");
 			label.setWrapText(true);
 			detailsGridPane.add(label, 0, count);
-			detailsGridPane.add(new Label(
-					new Identifier(0, 0, updateTransaction.getStakedNodeId()).toNicknameAndChecksum(nicknames)), 1, count++);
+			detailsGridPane.add(new Label(updateTransaction.getStakedNodeId().toString()), 1, count++);
 		}
 
 		if (updateTransaction.isDeclineStakingRewards() != null) {

--- a/tools-integration/pom.xml
+++ b/tools-integration/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<artifactId>hedera-transaction-tool</artifactId>
 		<groupId>com.hedera.hashgraph</groupId>
-		<version>0.11.0-beta.3</version>
+		<version>0.11.0-beta.4</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 
@@ -46,19 +46,19 @@
 		<dependency>
 			<groupId>com.hedera.hashgraph</groupId>
 			<artifactId>tools-core</artifactId>
-			<version>0.11.0-beta.3</version>
+			<version>0.11.0-beta.4</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.hedera.hashgraph</groupId>
 			<artifactId>tools-ui</artifactId>
-			<version>0.11.0-beta.3</version>
+			<version>0.11.0-beta.4</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.hedera.hashgraph</groupId>
 			<artifactId>tools-cli</artifactId>
-			<version>0.11.0-beta.3</version>
+			<version>0.11.0-beta.4</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/tools-ui/pom.xml
+++ b/tools-ui/pom.xml
@@ -26,7 +26,7 @@
 	<parent>
 		<artifactId>hedera-transaction-tool</artifactId>
 		<groupId>com.hedera.hashgraph</groupId>
-		<version>0.11.0-beta.3</version>
+		<version>0.11.0-beta.4</version>
 		<relativePath>../</relativePath>
 	</parent>
 
@@ -34,7 +34,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>tools-ui</artifactId>
-	<version>0.11.0-beta.3</version>
+	<version>0.11.0-beta.4</version>
 	<packaging>jar</packaging>
 
 	<!-- Project Properties -->
@@ -65,7 +65,7 @@
 		<dependency>
 			<groupId>com.hedera.hashgraph</groupId>
 			<artifactId>tools-core</artifactId>
-			<version>0.11.0-beta.3</version>
+			<version>0.11.0-beta.4</version>
 		</dependency>
 
 		<!-- SDK Dependency -->

--- a/tools-ui/src/main/java/com/hedera/hashgraph/client/ui/AccountsPaneController.java
+++ b/tools-ui/src/main/java/com/hedera/hashgraph/client/ui/AccountsPaneController.java
@@ -1285,8 +1285,7 @@ public class AccountsPaneController implements GenericFileReadWriteAware {
 
 		if (stakingInfo != null && stakingInfo.stakedNodeId != null) {
 			gridPane.add(setupBoxLabel("Staked Node ID"), 0, ++cnt);
-			final var stakingNodeIdStr = new Identifier(0, 0, info.stakingInfo.stakedNodeId).toReadableString();
-			gridPane.add(setupBoxTextField(format("%s (%s)", stakingNodeIdStr, AddressChecksums.checksum(stakingNodeIdStr))), 1, cnt);
+			gridPane.add(setupBoxTextField(info.stakingInfo.stakedNodeId.toString()), 1, cnt);
 		}
 
 		if (stakingInfo != null) {

--- a/tools-ui/src/main/resources/com/hedera/hashgraph/client/ui/CreatePane.fxml
+++ b/tools-ui/src/main/resources/com/hedera/hashgraph/client/ui/CreatePane.fxml
@@ -361,7 +361,7 @@
 						<Label text="Staked node ID"/>
 						<HBox alignment="CENTER_LEFT" spacing="20.0" VBox.vgrow="ALWAYS">
 							<TextField fx:id="stakedNodeIdField" alignment="CENTER" maxWidth="-Infinity" minWidth="300.0"
-									   promptText="X.X.XXXX" style="-fx-border-radius: 10; -fx-background-radius: 10;"/>
+									   style="-fx-border-radius: 10; -fx-background-radius: 10;"/>
 							<ImageView fitHeight="15.0" fitWidth="15.0" pickOnBounds="true" preserveRatio="true"
 									   visible="false">
 								<Image url="@../../../../../icons/greencheck.png"/>


### PR DESCRIPTION

**Description**:
don't validate staked node id against node account list, make it just a single number

**Related issue(s)**:

Fixes #391

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
