### PR TITLE
fix(#393 #386): ignore public key imports for keys where we have a private key, update license year to 2022

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 	<groupId>com.hedera.hashgraph</groupId>
 	<artifactId>hedera-transaction-tool</artifactId>
 
-	<version>0.11.0-beta.4</version>
+	<version>0.11.0-beta.5</version>
 	<name>Hedera Transaction Tool</name>
 
 	<modules>

--- a/tools-bom/pom.xml
+++ b/tools-bom/pom.xml
@@ -28,7 +28,7 @@
 	<parent>
 		<groupId>com.hedera.hashgraph</groupId>
 		<artifactId>hedera-transaction-tool</artifactId>
-		<version>0.11.0-beta.4</version>
+		<version>0.11.0-beta.5</version>
 	</parent>
 
 	<!-- Project Identifier & Type -->

--- a/tools-cli/pom.xml
+++ b/tools-cli/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<artifactId>hedera-transaction-tool</artifactId>
 		<groupId>com.hedera.hashgraph</groupId>
-		<version>0.11.0-beta.4</version>
+		<version>0.11.0-beta.5</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -33,7 +33,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>tools-cli</artifactId>
-	<version>0.11.0-beta.4</version>
+	<version>0.11.0-beta.5</version>
 	<packaging>jar</packaging>
 
 	<dependencyManagement>
@@ -53,7 +53,7 @@
 		<dependency>
 			<groupId>com.hedera.hashgraph</groupId>
 			<artifactId>tools-core</artifactId>
-			<version>0.11.0-beta.4</version>
+			<version>0.11.0-beta.5</version>
 		</dependency>
 
 		<!-- Logging SLF4j + Log4j2 implementation -->

--- a/tools-core/pom.xml
+++ b/tools-core/pom.xml
@@ -25,14 +25,14 @@
 	<parent>
 		<artifactId>hedera-transaction-tool</artifactId>
 		<groupId>com.hedera.hashgraph</groupId>
-		<version>0.11.0-beta.4</version>
+		<version>0.11.0-beta.5</version>
 	</parent>
 
 	<!-- Maven Model Version -->
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>tools-core</artifactId>
-	<version>0.11.0-beta.4</version>
+	<version>0.11.0-beta.5</version>
 	<packaging>jar</packaging>
 
 	<dependencyManagement>

--- a/tools-core/src/main/java/com/hedera/hashgraph/client/core/remote/BundleFile.java
+++ b/tools-core/src/main/java/com/hedera/hashgraph/client/core/remote/BundleFile.java
@@ -53,6 +53,7 @@ import java.util.stream.Collectors;
 import static com.hedera.hashgraph.client.core.constants.Constants.ACCOUNTS_MAP_FILE;
 import static com.hedera.hashgraph.client.core.constants.Constants.INFO_EXTENSION;
 import static com.hedera.hashgraph.client.core.constants.Constants.KEYS_FOLDER;
+import static com.hedera.hashgraph.client.core.constants.Constants.PK_EXTENSION;
 import static com.hedera.hashgraph.client.core.constants.Constants.PUB_EXTENSION;
 import static com.hedera.hashgraph.client.core.constants.Messages.BUNDLE_TITLE_MESSAGE_FORMAT;
 
@@ -117,7 +118,9 @@ public class BundleFile extends RemoteFile implements GenericFileReadWriteAware 
 					break;
 				case PUB_EXTENSION:
 					final var pubInfoKey = new PubInfoKey(file);
-					publicKeyMap.put(pubInfoKey, file);
+					if (!pubInfoKey.privateKeyExists()) {
+						publicKeyMap.put(pubInfoKey, file);
+					}
 					break;
 				default:
 					logger.error("Unexpected value: {}", name);
@@ -292,6 +295,11 @@ public class BundleFile extends RemoteFile implements GenericFileReadWriteAware 
 
 		public PublicKey getPublicKey() {
 			return publicKey;
+		}
+
+		public boolean privateKeyExists() {
+			return new File(KEYS_FOLDER, getNickname() + "." + PK_EXTENSION).exists()
+					|| new File(KEYS_FOLDER, getOldNickname() + "." + PK_EXTENSION).exists();
 		}
 
 		@Override

--- a/tools-integration/pom.xml
+++ b/tools-integration/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<artifactId>hedera-transaction-tool</artifactId>
 		<groupId>com.hedera.hashgraph</groupId>
-		<version>0.11.0-beta.4</version>
+		<version>0.11.0-beta.5</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 
@@ -46,19 +46,19 @@
 		<dependency>
 			<groupId>com.hedera.hashgraph</groupId>
 			<artifactId>tools-core</artifactId>
-			<version>0.11.0-beta.4</version>
+			<version>0.11.0-beta.5</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.hedera.hashgraph</groupId>
 			<artifactId>tools-ui</artifactId>
-			<version>0.11.0-beta.4</version>
+			<version>0.11.0-beta.5</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.hedera.hashgraph</groupId>
 			<artifactId>tools-cli</artifactId>
-			<version>0.11.0-beta.4</version>
+			<version>0.11.0-beta.5</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/tools-ui/pom.xml
+++ b/tools-ui/pom.xml
@@ -26,7 +26,7 @@
 	<parent>
 		<artifactId>hedera-transaction-tool</artifactId>
 		<groupId>com.hedera.hashgraph</groupId>
-		<version>0.11.0-beta.4</version>
+		<version>0.11.0-beta.5</version>
 		<relativePath>../</relativePath>
 	</parent>
 
@@ -34,7 +34,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>tools-ui</artifactId>
-	<version>0.11.0-beta.4</version>
+	<version>0.11.0-beta.5</version>
 	<packaging>jar</packaging>
 
 	<!-- Project Properties -->
@@ -65,7 +65,7 @@
 		<dependency>
 			<groupId>com.hedera.hashgraph</groupId>
 			<artifactId>tools-core</artifactId>
-			<version>0.11.0-beta.4</version>
+			<version>0.11.0-beta.5</version>
 		</dependency>
 
 		<!-- SDK Dependency -->

--- a/tools-ui/src/main/resources/license.txt
+++ b/tools-ui/src/main/resources/license.txt
@@ -1,6 +1,6 @@
 Hedera Transaction Tool
 
-Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+Copyright (C) 2018 - 2022 Hedera Hashgraph, LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
**Description**:
ignore public key imports for keys where we have a private key, update license year to 2022

**Related issue(s)**:

Fixes #393 #386

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
