### PR TITLE
496 transaction memo line truncates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 	<groupId>com.hedera.hashgraph</groupId>
 	<artifactId>hedera-transaction-tool</artifactId>
 
-	<version>0.13.1</version>
+	<version>0.13.2</version>
 	<name>Hedera Transaction Tool</name>
 
 	<modules>

--- a/tools-bom/pom.xml
+++ b/tools-bom/pom.xml
@@ -28,7 +28,7 @@
 	<parent>
 		<groupId>com.hedera.hashgraph</groupId>
 		<artifactId>hedera-transaction-tool</artifactId>
-		<version>0.13.1</version>
+		<version>0.13.2</version>
 	</parent>
 
 	<!-- Project Identifier & Type -->

--- a/tools-cli/pom.xml
+++ b/tools-cli/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<artifactId>hedera-transaction-tool</artifactId>
 		<groupId>com.hedera.hashgraph</groupId>
-		<version>0.13.1</version>
+		<version>0.13.2</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -33,7 +33,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>tools-cli</artifactId>
-	<version>0.13.1</version>
+	<version>0.13.2</version>
 	<packaging>jar</packaging>
 
 	<dependencyManagement>
@@ -53,7 +53,7 @@
 		<dependency>
 			<groupId>com.hedera.hashgraph</groupId>
 			<artifactId>tools-core</artifactId>
-			<version>0.13.1</version>
+			<version>0.13.2</version>
 		</dependency>
 
 		<!-- Logging SLF4j + Log4j2 implementation -->

--- a/tools-core/pom.xml
+++ b/tools-core/pom.xml
@@ -25,14 +25,14 @@
 	<parent>
 		<artifactId>hedera-transaction-tool</artifactId>
 		<groupId>com.hedera.hashgraph</groupId>
-		<version>0.13.1</version>
+		<version>0.13.2</version>
 	</parent>
 
 	<!-- Maven Model Version -->
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>tools-core</artifactId>
-	<version>0.13.1</version>
+	<version>0.13.2</version>
 
 	<dependencyManagement>
 		<dependencies>

--- a/tools-core/src/main/java/com/hedera/hashgraph/client/core/remote/TransactionFile.java
+++ b/tools-core/src/main/java/com/hedera/hashgraph/client/core/remote/TransactionFile.java
@@ -254,10 +254,10 @@ public class TransactionFile extends RemoteFile implements GenericFileReadWriteA
 
 		if (!"".equals(transaction.getMemo())) {
 			detailsGridPane.add(new Label("Memo: "), LEFT, ++count);
-			detailsGridPane.add(new Label(transaction.getMemo()), RIGHT, count);
+			var memo = new Label(transaction.getMemo());
+			memo.setWrapText(true);
+			detailsGridPane.add(memo, RIGHT, count);
 		}
-
-
 	}
 
 	/**

--- a/tools-core/src/main/java/com/hedera/hashgraph/client/core/remote/TransactionFile.java
+++ b/tools-core/src/main/java/com/hedera/hashgraph/client/core/remote/TransactionFile.java
@@ -406,7 +406,7 @@ public class TransactionFile extends RemoteFile implements GenericFileReadWriteA
 		}
 
 		if (updateTransaction.getAccountMemo() != null) {
-			handleAccountMemo(detailsGridPane, count, updateTransaction, hasOldInfo);
+			count = handleAccountMemo(detailsGridPane, count, updateTransaction, hasOldInfo);
 		}
 
 		try {
@@ -488,9 +488,9 @@ public class TransactionFile extends RemoteFile implements GenericFileReadWriteA
 		return count;
 	}
 
-	private void handleAccountMemo(final GridPane detailsGridPane, final int count,
-			final ToolCryptoUpdateTransaction updateTransaction, final boolean hasOldInfo) {
-		detailsGridPane.add(new Label("Account memo"), 0, count);
+	private int handleAccountMemo(final GridPane detailsGridPane, int count,
+								  final ToolCryptoUpdateTransaction updateTransaction, final boolean hasOldInfo) {
+		detailsGridPane.add(new Label("Account memo: "), 0, count);
 		final var newValue = updateTransaction.getAccountMemo();
 		final var labelString = (hasOldInfo && oldInfo.has(ACCOUNT_MEMO_FIELD_NAME)) ?
 				String.format("%s (updated from %s)", newValue,
@@ -498,7 +498,8 @@ public class TransactionFile extends RemoteFile implements GenericFileReadWriteA
 				String.format("%s", newValue);
 		final var label = new Label(labelString);
 		label.setWrapText(true);
-		detailsGridPane.add(label, 1, count);
+		detailsGridPane.add(label, 1, count++);
+		return count;
 	}
 
 	/**

--- a/tools-integration/pom.xml
+++ b/tools-integration/pom.xml
@@ -23,13 +23,13 @@
 	<parent>
 		<artifactId>hedera-transaction-tool</artifactId>
 		<groupId>com.hedera.hashgraph</groupId>
-		<version>0.13.1</version>
+		<version>0.13.2</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>tools-integration</artifactId>
-	<version>0.13.1</version>
+	<version>0.13.2</version>
 
 	<dependencyManagement>
 		<dependencies>
@@ -47,19 +47,19 @@
 		<dependency>
 			<groupId>com.hedera.hashgraph</groupId>
 			<artifactId>tools-core</artifactId>
-			<version>0.13.1</version>
+			<version>0.13.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.hedera.hashgraph</groupId>
 			<artifactId>tools-ui</artifactId>
-			<version>0.13.1</version>
+			<version>0.13.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.hedera.hashgraph</groupId>
 			<artifactId>tools-cli</artifactId>
-			<version>0.13.1</version>
+			<version>0.13.2</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/tools-ui/pom.xml
+++ b/tools-ui/pom.xml
@@ -26,7 +26,7 @@
 	<parent>
 		<artifactId>hedera-transaction-tool</artifactId>
 		<groupId>com.hedera.hashgraph</groupId>
-		<version>0.13.1</version>
+		<version>0.13.2</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -34,7 +34,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>tools-ui</artifactId>
-	<version>0.13.1</version>
+	<version>0.13.2</version>
 
 	<!-- Project Properties -->
 	<properties>
@@ -59,7 +59,7 @@
 		<dependency>
 			<groupId>com.hedera.hashgraph</groupId>
 			<artifactId>tools-core</artifactId>
-			<version>0.13.1</version>
+			<version>0.13.2</version>
 		</dependency>
 
 		<!-- SDK Dependency -->


### PR DESCRIPTION
**Description**:
The memo of the transaction was truncated when displayed on the Home Pane. It will now wrap and display the entire memo.

**Related issue(s)**:

Fixes #496 
