### PR TITLE
v0.13.2 User testing

### DIFF
--- a/tools-core/src/main/java/com/hedera/hashgraph/client/core/remote/TransactionFile.java
+++ b/tools-core/src/main/java/com/hedera/hashgraph/client/core/remote/TransactionFile.java
@@ -171,6 +171,7 @@ public class TransactionFile extends RemoteFile implements GenericFileReadWriteA
 		return transactionType;
 	}
 
+	@Override
 	public Timestamp getExpiration() {
 		return expiration;
 	}
@@ -329,6 +330,7 @@ public class TransactionFile extends RemoteFile implements GenericFileReadWriteA
 
 		detailsGridPane.add(new Label("Account memo: "), 0, count);
 		final var accountMemo = new Label(createTransaction.getAccountMemo());
+		accountMemo.setWrapText(true);
 		detailsGridPane.add(accountMemo, 1, count++);
 
 		final var sigReqLabel = new Label("Receiver signature required: ");
@@ -362,7 +364,7 @@ public class TransactionFile extends RemoteFile implements GenericFileReadWriteA
 		label.setWrapText(true);
 		detailsGridPane.add(label, 0, count);
 		detailsGridPane.add(new Label(String.format("%s", createTransaction.isDeclineStakingRewards())), 1,
-				count++);
+				count);
 	}
 
 	/**
@@ -438,7 +440,7 @@ public class TransactionFile extends RemoteFile implements GenericFileReadWriteA
 			label.setWrapText(true);
 			detailsGridPane.add(label, 0, count);
 			detailsGridPane.add(new Label(String.format("%s", updateTransaction.isDeclineStakingRewards())), 1,
-					count++);
+					count);
 		}
 	}
 

--- a/tools-ui/src/main/java/com/hedera/hashgraph/client/ui/CreatePaneController.java
+++ b/tools-ui/src/main/java/com/hedera/hashgraph/client/ui/CreatePaneController.java
@@ -94,6 +94,7 @@ import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableView;
 import javafx.scene.control.TextArea;
 import javafx.scene.control.TextField;
+import javafx.scene.control.TextInputControl;
 import javafx.scene.control.TreeView;
 import javafx.scene.control.cell.PropertyValueFactory;
 import javafx.scene.input.KeyCode;
@@ -160,7 +161,6 @@ import static com.hedera.hashgraph.client.core.constants.Constants.LARGE_BINARY_
 import static com.hedera.hashgraph.client.core.constants.Constants.LIMIT;
 import static com.hedera.hashgraph.client.core.constants.Constants.MAX_MEMO_BYTES;
 import static com.hedera.hashgraph.client.core.constants.Constants.MAX_TOKEN_AUTOMATIC_ASSOCIATIONS;
-import static com.hedera.hashgraph.client.core.constants.Constants.MEMO_LENGTH;
 import static com.hedera.hashgraph.client.core.constants.Constants.MEMO_PROPERTY;
 import static com.hedera.hashgraph.client.core.constants.Constants.MENU_BUTTON_STYLE;
 import static com.hedera.hashgraph.client.core.constants.Constants.NINE_ZEROS;
@@ -362,6 +362,7 @@ public class CreatePaneController implements SubController {
 	public DatePicker freezeDatePicker;
 
 	// Labels
+	public Label transactionMemoByteCount;
 	public Label totalTransferLabel;
 	public Label updateBytesRemaining;
 	public Label createMemoByteCount;
@@ -2150,7 +2151,7 @@ public class CreatePaneController implements SubController {
 				});
 	}
 
-	private void setMemoByteCounter(final TextField textField, final Label label) {
+	private void setMemoByteCounter(final TextInputControl textField, final Label label) {
 		final var text = textField.getText();
 		final var byteSize = text.getBytes(StandardCharsets.UTF_8).length;
 		if (byteSize > MAX_MEMO_BYTES) {
@@ -2764,8 +2765,8 @@ public class CreatePaneController implements SubController {
 	}
 
 	private void setupCommonFieldsEvents() {
-		memoField.lengthProperty().addListener((observable, oldValue, newValue) -> setTextSizeLimit(memoField,
-				MEMO_LENGTH, oldValue, newValue));
+		memoField.textProperty().addListener(
+				(observableValue, s, t1) -> setMemoByteCounter(memoField, transactionMemoByteCount));
 
 		nodeAccountField.setText(controller.getDefaultNodeID());
 

--- a/tools-ui/src/main/resources/com/hedera/hashgraph/client/ui/CreatePane.fxml
+++ b/tools-ui/src/main/resources/com/hedera/hashgraph/client/ui/CreatePane.fxml
@@ -219,11 +219,11 @@
 						<HBox alignment="CENTER_LEFT" spacing="20.0" VBox.vgrow="ALWAYS">
 							<TextArea fx:id="memoField" maxWidth="600.0" minWidth="600.0" prefRowCount="1"
 									  prefWidth="600.0" wrapText="true"/>
+							<Label fx:id="transactionMemoByteCount" text="Bytes remaining: 100"/>
 							<ImageView fitHeight="15.0" fitWidth="15.0" pickOnBounds="true" preserveRatio="true"
 									   visible="false">
 								<Image url="@../../../../../icons/greencheck.png"/>
 							</ImageView>
-							<Label text="Label" visible="false"/>
 						</HBox>
 					</VBox>
 					<VBox spacing="10.0">


### PR DESCRIPTION
**Description**:
There were a couple of other instance where the transaction memo or account memo where not displaying currently when the text was too long. This has been resolved.

The transaction memo field had no visual size limit indication. A visual indicator has been added.

**Related issue(s)**:

Fixes #500 #501 

