### PR TITLE
Resolved: 506-cannot-sign-a-transaction-on-the-home-screen

### DIFF
--- a/tools-core/src/main/java/com/hedera/hashgraph/client/core/remote/TransactionCreationMetadataFile.java
+++ b/tools-core/src/main/java/com/hedera/hashgraph/client/core/remote/TransactionCreationMetadataFile.java
@@ -152,7 +152,7 @@ public class TransactionCreationMetadataFile extends RemoteFile {
 			// If 0 or 1 node, AND 0 or 1 accounts, AND fee payer is NOT the updated account
 			// return null as no AccountListFile will be created.
 			if ((nodes == null || nodes.getList().size() == 1)
-					&& (accounts == null || accounts.getList().size() == 1)
+					&& (accounts == null || accounts.getList().size() <= 1)
 					&& !isUpdateAccountFeePayer) return null;
 			final var tcm = new TransactionCreationMetadataFile();
 			tcm.setParentPath(parentPath);

--- a/tools-ui/src/main/java/com/hedera/hashgraph/client/ui/HomePaneController.java
+++ b/tools-ui/src/main/java/com/hedera/hashgraph/client/ui/HomePaneController.java
@@ -203,6 +203,10 @@ public class HomePaneController implements SubController {
 		populatePane();
 	}
 
+	/**
+	 * Populating the Pane is a full refresh. This can be slow. Some changes do require a full refresh in
+	 * order to rebuild the RemoteFile gridPanes. An example would be account key changes.
+	 */
 	public void populatePane() {
 		try {
 			// Clear the list of RemoteFiles to be displayed


### PR DESCRIPTION
**Description**:
The new transaction metadata files were being created in unnecessary circumstances. Now, the metadata files won't be created unless needed.

Zipping a single transaction's .sig and .tx files was failing. It now will zip properly.

**Related issue(s)**:

Fixes #506 
