### PR TITLE
514 collation issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 	<groupId>com.hedera.hashgraph</groupId>
 	<artifactId>hedera-transaction-tool</artifactId>
 
-	<version>0.13.4-alpha.1</version>
+	<version>0.13.4</version>
 	<name>Hedera Transaction Tool</name>
 
 	<modules>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 	<groupId>com.hedera.hashgraph</groupId>
 	<artifactId>hedera-transaction-tool</artifactId>
 
-	<version>0.13.3</version>
+	<version>0.13.4-alpha.1</version>
 	<name>Hedera Transaction Tool</name>
 
 	<modules>

--- a/tools-bom/pom.xml
+++ b/tools-bom/pom.xml
@@ -28,7 +28,7 @@
 	<parent>
 		<groupId>com.hedera.hashgraph</groupId>
 		<artifactId>hedera-transaction-tool</artifactId>
-		<version>0.13.3</version>
+		<version>0.13.4-alpha.1</version>
 	</parent>
 
 	<!-- Project Identifier & Type -->

--- a/tools-bom/pom.xml
+++ b/tools-bom/pom.xml
@@ -28,7 +28,7 @@
 	<parent>
 		<groupId>com.hedera.hashgraph</groupId>
 		<artifactId>hedera-transaction-tool</artifactId>
-		<version>0.13.4-alpha.1</version>
+		<version>0.13.4</version>
 	</parent>
 
 	<!-- Project Identifier & Type -->

--- a/tools-cli/pom.xml
+++ b/tools-cli/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<artifactId>hedera-transaction-tool</artifactId>
 		<groupId>com.hedera.hashgraph</groupId>
-		<version>0.13.3</version>
+		<version>0.13.4-alpha.1</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -33,7 +33,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>tools-cli</artifactId>
-	<version>0.13.3</version>
+	<version>0.13.4-alpha.1</version>
 	<packaging>jar</packaging>
 
 	<dependencyManagement>
@@ -53,7 +53,7 @@
 		<dependency>
 			<groupId>com.hedera.hashgraph</groupId>
 			<artifactId>tools-core</artifactId>
-			<version>0.13.3</version>
+			<version>0.13.4-alpha.1</version>
 		</dependency>
 
 		<!-- Logging SLF4j + Log4j2 implementation -->

--- a/tools-cli/pom.xml
+++ b/tools-cli/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<artifactId>hedera-transaction-tool</artifactId>
 		<groupId>com.hedera.hashgraph</groupId>
-		<version>0.13.4-alpha.1</version>
+		<version>0.13.4</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -33,7 +33,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>tools-cli</artifactId>
-	<version>0.13.4-alpha.1</version>
+	<version>0.13.4</version>
 	<packaging>jar</packaging>
 
 	<dependencyManagement>
@@ -53,7 +53,7 @@
 		<dependency>
 			<groupId>com.hedera.hashgraph</groupId>
 			<artifactId>tools-core</artifactId>
-			<version>0.13.4-alpha.1</version>
+			<version>0.13.4</version>
 		</dependency>
 
 		<!-- Logging SLF4j + Log4j2 implementation -->

--- a/tools-cli/src/main/java/com/hedera/hashgraph/client/cli/helpers/OrderedExecutor.java
+++ b/tools-cli/src/main/java/com/hedera/hashgraph/client/cli/helpers/OrderedExecutor.java
@@ -1,0 +1,103 @@
+package com.hedera.hashgraph.client.cli.helpers;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.ExecutorService;
+
+/**
+ * This Executor warrants task ordering for tasks with same key (key have to implement hashCode and equal methods correctly).
+ */
+public class OrderedExecutor {
+
+    private final ExecutorService delegate;
+    private final Map<Object, Map<Object, Queue<Runnable>>> keyedTasks = new HashMap<>();
+
+    public OrderedExecutor(ExecutorService delegate){
+        this.delegate = delegate;
+    }
+
+    public void submit(Runnable task) {
+        // task without key can be executed immediately
+        delegate.submit(task);
+    }
+
+    public void submit(Runnable task, Object key, Object group) {
+        if (key == null){ // if key is null, execute without ordering
+            submit(task);
+            return;
+        }
+
+        boolean first = false;
+        Runnable wrappedTask;
+        synchronized (keyedTasks){
+            var groupedTasks = keyedTasks.get(key);
+            if (groupedTasks == null) {
+                groupedTasks = new HashMap<>();
+                keyedTasks.put(key, groupedTasks);
+            }
+            var dependencyQueue = groupedTasks.get(group);
+            if (dependencyQueue == null) {
+                dependencyQueue = new LinkedList<>();
+                groupedTasks.put(group, dependencyQueue);
+                first = true;
+            }
+            wrappedTask = wrap(task, dependencyQueue, key, group);
+            dependencyQueue.add(wrappedTask);
+        }
+
+        if (first) {
+            submit(wrappedTask);
+        }
+    }
+
+    private Runnable wrap(final Runnable task,
+                          final Queue<Runnable> dependencyQueue,
+                          final Object key, final Object group) {
+        return new OrderedTask(task, dependencyQueue, key, group);
+    }
+
+    class OrderedTask implements Runnable{
+
+        private final Queue<Runnable> dependencyQueue;
+        private final Runnable task;
+        private final Object key;
+        private final Object group;
+
+        public OrderedTask(final Runnable task,
+                           final Queue<Runnable> dependencyQueue,
+                           final Object key, final Object group) {
+            this.task = task;
+            this.dependencyQueue = dependencyQueue;
+            this.key = key;
+            this.group = group;
+        }
+
+        @Override
+        public void run() {
+            try{
+                task.run();
+            } finally {
+                Runnable nextTask = null;
+                synchronized (keyedTasks) {
+                    dependencyQueue.remove(this);
+                    if (dependencyQueue.isEmpty()) {
+                        final var groupedTasks = keyedTasks.get(group);
+                        groupedTasks.remove(group);
+                        if (groupedTasks.isEmpty()) {
+                            keyedTasks.remove(key);
+                        }
+                    } else {
+                        nextTask = dependencyQueue.peek();
+                    }
+                }
+                //TODO this task should be grouped with all the other tasks of this level, they should all fire off
+                // at the same time.
+                if (nextTask != null) {
+                    submit(nextTask);
+                }
+            }
+        }
+    }
+}

--- a/tools-core/pom.xml
+++ b/tools-core/pom.xml
@@ -25,14 +25,14 @@
 	<parent>
 		<artifactId>hedera-transaction-tool</artifactId>
 		<groupId>com.hedera.hashgraph</groupId>
-		<version>0.13.3</version>
+		<version>0.13.4-alpha.1</version>
 	</parent>
 
 	<!-- Maven Model Version -->
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>tools-core</artifactId>
-	<version>0.13.3</version>
+	<version>0.13.4-alpha.1</version>
 
 	<dependencyManagement>
 		<dependencies>

--- a/tools-core/pom.xml
+++ b/tools-core/pom.xml
@@ -25,14 +25,14 @@
 	<parent>
 		<artifactId>hedera-transaction-tool</artifactId>
 		<groupId>com.hedera.hashgraph</groupId>
-		<version>0.13.4-alpha.1</version>
+		<version>0.13.4</version>
 	</parent>
 
 	<!-- Maven Model Version -->
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>tools-core</artifactId>
-	<version>0.13.4-alpha.1</version>
+	<version>0.13.4</version>
 
 	<dependencyManagement>
 		<dependencies>

--- a/tools-core/src/main/java/com/hedera/hashgraph/client/core/helpers/TransactionCallableWorker.java
+++ b/tools-core/src/main/java/com/hedera/hashgraph/client/core/helpers/TransactionCallableWorker.java
@@ -44,13 +44,42 @@ public class TransactionCallableWorker implements Callable<TxnResult>, GenericFi
 
 	private static final Logger logger = LogManager.getLogger(TransactionCallableWorker.class);
 
+	// As transactions can be duplicated and submitted to multiple nodes simultaneously, the TxnResults
+	// were also duplicated. Each duplicate TxnResult, however, was pointing to the same receipt. This resulted
+	// in the final response indicated that transactionCount*nodeCount number of transactions were submitted
+	// and successCount*nodeCount were successful. If TxnResult is strongly tied to the transactionId, these
+	// duplicates can be removed.
 	public static class TxnResult {
-		public final String message;
-		public final boolean success;
+		private final String transactionId;
+		private final boolean success;
+		private final String message;
 
-		public TxnResult(String message, boolean success) {
-			this.message = message;
+		public TxnResult(String transactionId, boolean success, String message) {
+			this.transactionId = transactionId;
 			this.success = success;
+			this.message = message;
+		}
+
+		public String getTransactionId() {
+			return transactionId;
+		}
+
+		public boolean wasSuccessful() {
+			return success;
+		}
+
+		public String getMessage() {
+			return message;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			return obj instanceof TxnResult && Objects.equals(((TxnResult)obj).getTransactionId(), getTransactionId());
+		}
+
+		@Override
+		public int hashCode() {
+			return getTransactionId().hashCode();
 		}
 	}
 
@@ -129,6 +158,10 @@ public class TransactionCallableWorker implements Callable<TxnResult>, GenericFi
 			long retryDelay = 1000;
 			boolean forceRetry = false;
 
+			//TODO getting the receipt should actually be its own task
+			// so, this should return a gettingReceipt task, not a txnresult
+			// then that should be added to the executor, and that's what the executor stuff should wait for
+			// in the end
 			while (true) {
 
 				if (forceRetry || receipt == null || status == null || retryStatuses.contains(status)) {
@@ -182,14 +215,14 @@ public class TransactionCallableWorker implements Callable<TxnResult>, GenericFi
 				logger.info("Worker: Transaction: {}, final status: {}", idString, status);
 
 				storeResponse(receipt, idString);
-				return new TxnResult("Final status for " + idString + " - " + status, Status.SUCCESS.equals(status));
+				return new TxnResult(idString, Status.SUCCESS.equals(status), "Final status for " + idString + " - " + status);
 			} else {
 				throw new HederaClientRuntimeException("could not get receipt for " + idString);
 			}
 		} catch (final Exception e) {
 			logger.error("Worker: Transaction: " + idString + ", failed with error. ", e);
 		}
-		return new TxnResult(idString + " - Threw Exception", false);
+		return new TxnResult(idString, false, idString + " - Threw Exception");
 	}
 
 	private void sleepUntilNeeded() throws InterruptedException {

--- a/tools-integration/pom.xml
+++ b/tools-integration/pom.xml
@@ -23,13 +23,13 @@
 	<parent>
 		<artifactId>hedera-transaction-tool</artifactId>
 		<groupId>com.hedera.hashgraph</groupId>
-		<version>0.13.3</version>
+		<version>0.13.4-alpha.1</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>tools-integration</artifactId>
-	<version>0.13.3</version>
+	<version>0.13.4-alpha.1</version>
 
 	<dependencyManagement>
 		<dependencies>
@@ -47,19 +47,19 @@
 		<dependency>
 			<groupId>com.hedera.hashgraph</groupId>
 			<artifactId>tools-core</artifactId>
-			<version>0.13.3</version>
+			<version>0.13.4-alpha.1</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.hedera.hashgraph</groupId>
 			<artifactId>tools-ui</artifactId>
-			<version>0.13.3</version>
+			<version>0.13.4-alpha.1</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.hedera.hashgraph</groupId>
 			<artifactId>tools-cli</artifactId>
-			<version>0.13.3</version>
+			<version>0.13.4-alpha.1</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/tools-integration/pom.xml
+++ b/tools-integration/pom.xml
@@ -23,13 +23,13 @@
 	<parent>
 		<artifactId>hedera-transaction-tool</artifactId>
 		<groupId>com.hedera.hashgraph</groupId>
-		<version>0.13.4-alpha.1</version>
+		<version>0.13.4</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>tools-integration</artifactId>
-	<version>0.13.4-alpha.1</version>
+	<version>0.13.4</version>
 
 	<dependencyManagement>
 		<dependencies>
@@ -47,19 +47,19 @@
 		<dependency>
 			<groupId>com.hedera.hashgraph</groupId>
 			<artifactId>tools-core</artifactId>
-			<version>0.13.4-alpha.1</version>
+			<version>0.13.4</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.hedera.hashgraph</groupId>
 			<artifactId>tools-ui</artifactId>
-			<version>0.13.4-alpha.1</version>
+			<version>0.13.4</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.hedera.hashgraph</groupId>
 			<artifactId>tools-cli</artifactId>
-			<version>0.13.4-alpha.1</version>
+			<version>0.13.4</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/tools-ui/pom.xml
+++ b/tools-ui/pom.xml
@@ -26,7 +26,7 @@
 	<parent>
 		<artifactId>hedera-transaction-tool</artifactId>
 		<groupId>com.hedera.hashgraph</groupId>
-		<version>0.13.4-alpha.1</version>
+		<version>0.13.4</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -34,7 +34,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>tools-ui</artifactId>
-	<version>0.13.4-alpha.1</version>
+	<version>0.13.4</version>
 
 	<!-- Project Properties -->
 	<properties>
@@ -59,7 +59,7 @@
 		<dependency>
 			<groupId>com.hedera.hashgraph</groupId>
 			<artifactId>tools-core</artifactId>
-			<version>0.13.4-alpha.1</version>
+			<version>0.13.4</version>
 		</dependency>
 
 		<!-- SDK Dependency -->

--- a/tools-ui/pom.xml
+++ b/tools-ui/pom.xml
@@ -26,7 +26,7 @@
 	<parent>
 		<artifactId>hedera-transaction-tool</artifactId>
 		<groupId>com.hedera.hashgraph</groupId>
-		<version>0.13.3</version>
+		<version>0.13.4-alpha.1</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -34,7 +34,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>tools-ui</artifactId>
-	<version>0.13.3</version>
+	<version>0.13.4-alpha.1</version>
 
 	<!-- Project Properties -->
 	<properties>
@@ -59,7 +59,7 @@
 		<dependency>
 			<groupId>com.hedera.hashgraph</groupId>
 			<artifactId>tools-core</artifactId>
-			<version>0.13.3</version>
+			<version>0.13.4-alpha.1</version>
 		</dependency>
 
 		<!-- SDK Dependency -->


### PR DESCRIPTION
**Description**:
A high priority release. The SubmitCommand was submitting transactions one after another, in order. In the case of a FileUpdateTransaction and the accompanying FileAppendTransactions, this could be an issue if sent to multiple nodes simultaneously. This is resolved by forcing transactions of these type to queue up separately and require a response before submitting the next in the queue. 

In order to ensure the submits from FileUpdateTransaction and FileAppendTransactions don't expire while waiting in the queue, the separation of these transactions' validTimestamps is 10 seconds. This will be a setting the user can set in the future.
