### PR TITLE
Key information missing from Home Pane

### DIFF
--- a/tools-ui/src/main/java/com/hedera/hashgraph/client/ui/HomePaneController.java
+++ b/tools-ui/src/main/java/com/hedera/hashgraph/client/ui/HomePaneController.java
@@ -280,9 +280,6 @@ public class HomePaneController implements SubController {
 						if (controller.historyPaneController.isHistory(file.hashCode())) {
 							file.setHistory(true);
 						} else {
-							if (file instanceof TransactionFile) {
-								setupKeyTree((TransactionFile) file);
-							}
 							buildAndAddBox(file);
 						}
 					}
@@ -437,6 +434,11 @@ public class HomePaneController implements SubController {
 					PopupMessage.display("File Link Error", e.getMessage());
 				}
 			});
+		}
+
+		// If the file is a TransactionFile, set up the key tree(s)
+		if (file instanceof TransactionFile) {
+			setupKeyTree((TransactionFile) file);
 		}
 
 		// Build the details box for the RemoteFile


### PR DESCRIPTION
**Description**:
When a transaction has a key that needs to be displayed from the HomePane (like in an account update), this creation of the key tree was only occurring when the home pane was completely recreated. As this is no longer done, there were times when the key tree was not being created for a transaction until the whole app was closed and reopened. This has now been resolved, the key tree will always be created when it is required.

**Related issue(s)**:

Fixes #532 
