### PR TITLE
538 resizing bug with transfer tables

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 	<groupId>com.hedera.hashgraph</groupId>
 	<artifactId>hedera-transaction-tool</artifactId>
 
-	<version>0.14.0</version>
+	<version>0.14.1</version>
 	<name>Hedera Transaction Tool</name>
 
 	<modules>

--- a/tools-bom/pom.xml
+++ b/tools-bom/pom.xml
@@ -28,7 +28,7 @@
 	<parent>
 		<groupId>com.hedera.hashgraph</groupId>
 		<artifactId>hedera-transaction-tool</artifactId>
-		<version>0.14.0</version>
+		<version>0.14.1</version>
 	</parent>
 
 	<!-- Project Identifier & Type -->

--- a/tools-cli/pom.xml
+++ b/tools-cli/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<artifactId>hedera-transaction-tool</artifactId>
 		<groupId>com.hedera.hashgraph</groupId>
-		<version>0.14.0</version>
+		<version>0.14.1</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -33,7 +33,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>tools-cli</artifactId>
-	<version>0.14.0</version>
+	<version>0.14.1</version>
 	<packaging>jar</packaging>
 
 	<dependencyManagement>
@@ -53,7 +53,7 @@
 		<dependency>
 			<groupId>com.hedera.hashgraph</groupId>
 			<artifactId>tools-core</artifactId>
-			<version>0.14.0</version>
+			<version>0.14.1</version>
 		</dependency>
 
 		<!-- Logging SLF4j + Log4j2 implementation -->

--- a/tools-core/pom.xml
+++ b/tools-core/pom.xml
@@ -25,14 +25,14 @@
 	<parent>
 		<artifactId>hedera-transaction-tool</artifactId>
 		<groupId>com.hedera.hashgraph</groupId>
-		<version>0.14.0</version>
+		<version>0.14.1</version>
 	</parent>
 
 	<!-- Maven Model Version -->
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>tools-core</artifactId>
-	<version>0.14.0</version>
+	<version>0.14.1</version>
 
 	<dependencyManagement>
 		<dependencies>

--- a/tools-core/src/main/java/com/hedera/hashgraph/client/core/transactions/ToolCryptoCreateTransaction.java
+++ b/tools-core/src/main/java/com/hedera/hashgraph/client/core/transactions/ToolCryptoCreateTransaction.java
@@ -244,6 +244,7 @@ public class ToolCryptoCreateTransaction extends ToolTransaction {
 	@Override
 	public Set<ByteString> getSigningKeys(final String accountsInfoFolder) {
 		final var keysSet = super.getSigningKeys(accountsInfoFolder);
+		// The keys of the new account are not actually required for signing. This isn't needed.
 		keysSet.addAll(EncryptionUtils.flatPubKeys(
 				Collections.singletonList(((AccountCreateTransaction) transaction).getKey())));
 		return keysSet;

--- a/tools-integration/pom.xml
+++ b/tools-integration/pom.xml
@@ -23,13 +23,13 @@
 	<parent>
 		<artifactId>hedera-transaction-tool</artifactId>
 		<groupId>com.hedera.hashgraph</groupId>
-		<version>0.14.0</version>
+		<version>0.14.1</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>tools-integration</artifactId>
-	<version>0.14.0</version>
+	<version>0.14.1</version>
 
 	<dependencyManagement>
 		<dependencies>
@@ -47,19 +47,19 @@
 		<dependency>
 			<groupId>com.hedera.hashgraph</groupId>
 			<artifactId>tools-core</artifactId>
-			<version>0.14.0</version>
+			<version>0.14.1</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.hedera.hashgraph</groupId>
 			<artifactId>tools-ui</artifactId>
-			<version>0.14.0</version>
+			<version>0.14.1</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.hedera.hashgraph</groupId>
 			<artifactId>tools-cli</artifactId>
-			<version>0.14.0</version>
+			<version>0.14.1</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/tools-ui/pom.xml
+++ b/tools-ui/pom.xml
@@ -26,7 +26,7 @@
 	<parent>
 		<artifactId>hedera-transaction-tool</artifactId>
 		<groupId>com.hedera.hashgraph</groupId>
-		<version>0.14.0</version>
+		<version>0.14.1</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -34,7 +34,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>tools-ui</artifactId>
-	<version>0.14.0</version>
+	<version>0.14.1</version>
 
 	<!-- Project Properties -->
 	<properties>
@@ -59,7 +59,7 @@
 		<dependency>
 			<groupId>com.hedera.hashgraph</groupId>
 			<artifactId>tools-core</artifactId>
-			<version>0.14.0</version>
+			<version>0.14.1</version>
 		</dependency>
 
 		<!-- SDK Dependency -->

--- a/tools-ui/src/main/java/com/hedera/hashgraph/client/ui/CreatePaneController.java
+++ b/tools-ui/src/main/java/com/hedera/hashgraph/client/ui/CreatePaneController.java
@@ -494,7 +494,9 @@ public class CreatePaneController implements SubController {
 				freezeFileHashTextField, stakedAccountIdField, stakedNodeIdField
 		);
 
-		setupTransferFields();
+		if (!initialized) {
+			setupTransferFields();
+		}
 
 		setupCreateFields();
 
@@ -542,14 +544,12 @@ public class CreatePaneController implements SubController {
 		transferTableEvents(transferToAccountIDTextField, transferToAmountTextField, toTransferTable,
 				acceptToAccountButton, errorInvalidToAccount);
 
-		if (!initialized) {
-			transferFromAmountTextField.textProperty().addListener(
-					(observable, oldValue, newValue) -> fixNumericTextField(transferFromAmountTextField, newValue, "\\d*",
-							"[^\\d.]"));
-			transferToAmountTextField.textProperty().addListener(
-					(observable, oldValue, newValue) -> fixNumericTextField(transferToAmountTextField, newValue, "\\d*",
-							"[^\\d.]"));
-		}
+		transferFromAmountTextField.textProperty().addListener(
+				(observable, oldValue, newValue) -> fixNumericTextField(transferFromAmountTextField, newValue, "\\d*",
+						"[^\\d.]"));
+		transferToAmountTextField.textProperty().addListener(
+				(observable, oldValue, newValue) -> fixNumericTextField(transferToAmountTextField, newValue, "\\d*",
+						"[^\\d.]"));
 
 		final BooleanProperty transferBoolean = new SimpleBooleanProperty();
 		transferBoolean.setValue(toTransferTable.getItems().isEmpty() ^ fromTransferTable.getItems().isEmpty());
@@ -1418,15 +1418,9 @@ public class CreatePaneController implements SubController {
 			}
 		});
 
-		if (!initialized) {
-			table.getItems().addListener(
-					(ListChangeListener<AccountAmountStrings>) change -> table.setMinHeight(table.getFixedCellSize() * (
-							!change.getList().isEmpty() ? table.getItems().size() + 1.1 : 2.1)));
-
-		}
-		table.prefHeightProperty().bind(
-				table.fixedCellSizeProperty().multiply(Bindings.size(table.getItems()).add(1.1)));
-
+		table.minHeightProperty().bind(
+				table.fixedCellSizeProperty().multiply(Bindings.max(1, Bindings.size(table.getItems())).add(1.1)));
+		table.prefHeightProperty().bind(table.minHeightProperty());
 		table.maxHeightProperty().bind(table.prefHeightProperty());
 		table.managedProperty().bind(table.visibleProperty());
 	}
@@ -1495,13 +1489,11 @@ public class CreatePaneController implements SubController {
 			}
 		});
 
-		if (!initialized) {
-			amountTextField.focusedProperty().addListener((arg0, oldPropertyValue, newPropertyValue) -> {
-				if (Boolean.FALSE.equals(newPropertyValue)) {
-					setHBarFormat(amountTextField);
-				}
-			});
-		}
+		amountTextField.focusedProperty().addListener((arg0, oldPropertyValue, newPropertyValue) -> {
+			if (Boolean.FALSE.equals(newPropertyValue)) {
+				setHBarFormat(amountTextField);
+			}
+		});
 
 
 		acceptButton.setOnKeyPressed((KeyEvent event) -> {


### PR DESCRIPTION
**Description**:
The Tool was designed to rebuild each pane very often. This would happen after changes, when selecting a new tab, saving newly created transactions, etc. One issue this would cause is that components that had listeners assigned to them, would have multiple duplicate listeners. A fix was implemented to prevent this. This fix was small and designed not to require a rewrite of the panes. 

One of the listeners was a list size change listener. It would resize the transfer table after a new transfer amount was added, or removed. This listener, unlike the others, was being cleared out every re-initialization of a pane. This caused the tables to stop resizing appropriately. This listener has been replaced with a binding, which fixes the issue.

**Related issue(s)**:

Fixes #538 

**Notes for reviewer**:
Only 1 block of code was changed (and a comment added elsewhere). The change was a listener removed and a binding implemented.

