### PR TITLE
ci: replace action with step-security maintained version

### DIFF
--- a/.github/workflows/openjdk_14_build.yml
+++ b/.github/workflows/openjdk_14_build.yml
@@ -47,7 +47,7 @@ jobs:
         run: ./mvnw $MAVEN_CLI_OPTS test
 
       - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1
+        uses: step-security/publish-unit-test-result-action@97e3e8db4f0406df69ad75ce125553e13bd998a9 #v1
         if: always()
         with:
           files: "*/target/surefire-reports/*.xml"

--- a/.github/workflows/openjdk_14_build.yml
+++ b/.github/workflows/openjdk_14_build.yml
@@ -47,7 +47,7 @@ jobs:
         run: ./mvnw $MAVEN_CLI_OPTS test
 
       - name: Publish Unit Test Results
-        uses: step-security/publish-unit-test-result-action@97e3e8db4f0406df69ad75ce125553e13bd998a9 #v1
+        uses: step-security/publish-unit-test-result-action@cc82caac074385ae176d39d2d143ad05e1130b2d # v2.18.0
         if: always()
         with:
           files: "*/target/surefire-reports/*.xml"


### PR DESCRIPTION
**Description**:
replace EnricoMi/publish-unit-test-result-action with step-security version

**Related issue(s)**:

Fixes #569 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
