### PR TITLE
bug: CLI operations fail if using java 17

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ and is at your own risk.
 
 # Install
 ## Requirements
-* Java 17+ and JavaFX (sdk install java 17.0.13.fx-zulu)
+* Java 21+ and JavaFX (sdk install java 17.0.13.fx-zulu)
 * MacOS (currently does not support other operating systems)
 
 You can download the packages for the Hedera Transaction Tool UI and CLI by downloading the assets in each tag.


### PR DESCRIPTION
**Description**:
After upgrading to Java 21, the error did not occur again. All reading indicates the issue was caused by the version of Java. 

**Related issue(s)**:

Fixes 
#577 
#561  

**Notes for reviewer**:
We had 2 failing environments, 1 with the reported error, one with a very similar error. After updating both environments to Java 21, both errors were resolved.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
