### PR TITLE
fix: Account Info Queries for non mainnet networks, allow for waiving signing requirements as needed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 	<groupId>com.hedera.hashgraph</groupId>
 	<artifactId>hedera-transaction-tool</artifactId>
 
-	<version>0.14.5</version>
+	<version>0.14.6</version>
 	<name>Hedera Transaction Tool</name>
 
 	<modules>

--- a/tools-bom/pom.xml
+++ b/tools-bom/pom.xml
@@ -28,7 +28,7 @@
 	<parent>
 		<groupId>com.hedera.hashgraph</groupId>
 		<artifactId>hedera-transaction-tool</artifactId>
-		<version>0.14.5</version>
+		<version>0.14.6</version>
 	</parent>
 
 	<!-- Project Identifier & Type -->

--- a/tools-cli/pom.xml
+++ b/tools-cli/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<artifactId>hedera-transaction-tool</artifactId>
 		<groupId>com.hedera.hashgraph</groupId>
-		<version>0.14.5</version>
+		<version>0.14.6</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -33,7 +33,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>tools-cli</artifactId>
-	<version>0.14.5</version>
+	<version>0.14.6</version>
 	<packaging>jar</packaging>
 
 	<dependencyManagement>
@@ -53,7 +53,7 @@
 		<dependency>
 			<groupId>com.hedera.hashgraph</groupId>
 			<artifactId>tools-core</artifactId>
-			<version>0.14.5</version>
+			<version>0.14.6</version>
 		</dependency>
 
 		<!-- SDK Dependency - this is required for creating custom clients -->

--- a/tools-core/pom.xml
+++ b/tools-core/pom.xml
@@ -25,14 +25,14 @@
 	<parent>
 		<artifactId>hedera-transaction-tool</artifactId>
 		<groupId>com.hedera.hashgraph</groupId>
-		<version>0.14.5</version>
+		<version>0.14.6</version>
 	</parent>
 
 	<!-- Maven Model Version -->
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>tools-core</artifactId>
-	<version>0.14.5</version>
+	<version>0.14.6</version>
 
 	<dependencyManagement>
 		<dependencies>

--- a/tools-integration/pom.xml
+++ b/tools-integration/pom.xml
@@ -23,13 +23,13 @@
 	<parent>
 		<artifactId>hedera-transaction-tool</artifactId>
 		<groupId>com.hedera.hashgraph</groupId>
-		<version>0.14.5</version>
+		<version>0.14.6</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>tools-integration</artifactId>
-	<version>0.14.5</version>
+	<version>0.14.6</version>
 
 	<dependencyManagement>
 		<dependencies>
@@ -47,19 +47,19 @@
 		<dependency>
 			<groupId>com.hedera.hashgraph</groupId>
 			<artifactId>tools-core</artifactId>
-			<version>0.14.5</version>
+			<version>0.14.6</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.hedera.hashgraph</groupId>
 			<artifactId>tools-ui</artifactId>
-			<version>0.14.5</version>
+			<version>0.14.6</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.hedera.hashgraph</groupId>
 			<artifactId>tools-cli</artifactId>
-			<version>0.14.5</version>
+			<version>0.14.6</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/tools-ui/pom.xml
+++ b/tools-ui/pom.xml
@@ -26,7 +26,7 @@
 	<parent>
 		<artifactId>hedera-transaction-tool</artifactId>
 		<groupId>com.hedera.hashgraph</groupId>
-		<version>0.14.5</version>
+		<version>0.14.6</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -34,7 +34,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>tools-ui</artifactId>
-	<version>0.14.5</version>
+	<version>0.14.6</version>
 
 	<!-- Project Properties -->
 	<properties>
@@ -59,7 +59,7 @@
 		<dependency>
 			<groupId>com.hedera.hashgraph</groupId>
 			<artifactId>tools-core</artifactId>
-			<version>0.14.5</version>
+			<version>0.14.6</version>
 		</dependency>
 
 		<!-- SDK Dependency -->

--- a/tools-ui/src/main/java/com/hedera/hashgraph/client/ui/AccountsPaneController.java
+++ b/tools-ui/src/main/java/com/hedera/hashgraph/client/ui/AccountsPaneController.java
@@ -522,7 +522,6 @@ public class AccountsPaneController implements SubController {
 		return "Request " + e.getMessage();
 	}
 
-
 	@NotNull
 	private AccountInfoQuery getAccountInfoQuery(final Identifier feePayer, final Set<File> privateKeysFiles) {
 
@@ -533,8 +532,15 @@ public class AccountsPaneController implements SubController {
 								FilenameUtils.getBaseName(privateKeyFile.getName())))).map(
 						keyPair -> PrivateKey.fromBytes(keyPair.getPrivate().getEncoded())).collect(Collectors.toList());
 
+		final var network = networkChoiceBoxA.getValue();
+		var networkString = controller.getCurrentNetwork();
+		// If there is a selection, then it is a String
+		if (network instanceof String) {
+			networkString = (String) network;
+		}
 		return AccountInfoQuery.Builder
 				.anAccountInfoQuery()
+				.withNetwork(networkString)
 				.withSigningKeys(privateKeys)
 				.withFeePayer(feePayer.asAccount())
 				.withFee(Hbar.fromTinybars(controller.getDefaultTxFee()))


### PR DESCRIPTION
**Description**:
Account info queries always defaulted to Mainnet, despite having the choice selection. The code didn't exist to allow the user to chose the network when getting account info. This has been corrected, now the selection of network will properly direct the query.

In addition, there are some very specific cases where the signing requirements should be waived. This has been corrected.

**Related issue(s)**:

Fixes #582, #583 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
