### PR TITLE
Feat export signatures as json

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 	<groupId>com.hedera.hashgraph</groupId>
 	<artifactId>hedera-transaction-tool</artifactId>
 
-	<version>0.14.7</version>
+	<version>0.14.8</version>
 	<name>Hedera Transaction Tool</name>
 
 	<modules>

--- a/tools-bom/pom.xml
+++ b/tools-bom/pom.xml
@@ -28,7 +28,7 @@
 	<parent>
 		<groupId>com.hedera.hashgraph</groupId>
 		<artifactId>hedera-transaction-tool</artifactId>
-		<version>0.14.7</version>
+		<version>0.14.8</version>
 	</parent>
 
 	<!-- Project Identifier & Type -->

--- a/tools-cli/pom.xml
+++ b/tools-cli/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<artifactId>hedera-transaction-tool</artifactId>
 		<groupId>com.hedera.hashgraph</groupId>
-		<version>0.14.7</version>
+		<version>0.14.8</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -33,7 +33,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>tools-cli</artifactId>
-	<version>0.14.7</version>
+	<version>0.14.8</version>
 	<packaging>jar</packaging>
 
 	<dependencyManagement>
@@ -53,7 +53,7 @@
 		<dependency>
 			<groupId>com.hedera.hashgraph</groupId>
 			<artifactId>tools-core</artifactId>
-			<version>0.14.7</version>
+			<version>0.14.8</version>
 		</dependency>
 
 		<!-- SDK Dependency - this is required for creating custom clients -->

--- a/tools-core/pom.xml
+++ b/tools-core/pom.xml
@@ -25,14 +25,14 @@
 	<parent>
 		<artifactId>hedera-transaction-tool</artifactId>
 		<groupId>com.hedera.hashgraph</groupId>
-		<version>0.14.7</version>
+		<version>0.14.8</version>
 	</parent>
 
 	<!-- Maven Model Version -->
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>tools-core</artifactId>
-	<version>0.14.7</version>
+	<version>0.14.8</version>
 
 	<dependencyManagement>
 		<dependencies>

--- a/tools-core/src/main/java/com/hedera/hashgraph/client/core/remote/LargeBinaryFile.java
+++ b/tools-core/src/main/java/com/hedera/hashgraph/client/core/remote/LargeBinaryFile.java
@@ -941,7 +941,7 @@ public class LargeBinaryFile extends RemoteFile implements GenericFileReadWriteA
 			zipMessages(String.format("%s%s.%s", baseName, TRANSACTIONS_SUFFIX, ZIP_EXTENSION),
 					TRANSACTION_EXTENSION);
 			zipMessages(String.format("%s%s.%s", baseName, SIGNATURES_SUFFIX, ZIP_EXTENSION),
-					SIGNATURE_EXTENSION);
+					SIGNATURE_EXTENSION, JSON_EXTENSION);
 		}
 
 		private void summarizeTransactions(final String baseName) throws HederaClientException, IOException {
@@ -988,9 +988,9 @@ public class LargeBinaryFile extends RemoteFile implements GenericFileReadWriteA
 			return null;
 		}
 
-		private void zipMessages(final String messages, final String ext) throws HederaClientException {
+		private void zipMessages(final String messages, final String... exts) throws HederaClientException {
 			try {
-				final var txToPack = new File(tempStorage).listFiles((dir, name) -> name.endsWith(ext));
+				final var txToPack = new File(tempStorage).listFiles((dir, name) -> Arrays.stream(exts).anyMatch(name::endsWith));
 				if (txToPack == null) {
 					throw new HederaClientRuntimeException("Unable to read list of transactions to pack");
 				}

--- a/tools-core/src/main/java/com/hedera/hashgraph/client/core/remote/TransactionFile.java
+++ b/tools-core/src/main/java/com/hedera/hashgraph/client/core/remote/TransactionFile.java
@@ -98,6 +98,7 @@ import static com.hedera.hashgraph.client.core.constants.Constants.CREDIT;
 import static com.hedera.hashgraph.client.core.constants.Constants.DEBIT;
 import static com.hedera.hashgraph.client.core.constants.Constants.FILE_NAME_GROUP_SEPARATOR;
 import static com.hedera.hashgraph.client.core.constants.Constants.FILE_NAME_INTERNAL_SEPARATOR;
+import static com.hedera.hashgraph.client.core.constants.Constants.JSON_EXTENSION;
 import static com.hedera.hashgraph.client.core.constants.Constants.SIGNATURE_EXTENSION;
 import static com.hedera.hashgraph.client.core.constants.Constants.TRANSACTION_EXTENSION;
 import static com.hedera.hashgraph.client.core.constants.Constants.WHITE_BUTTON_STYLE;
@@ -1152,7 +1153,7 @@ public class TransactionFile extends RemoteFile implements GenericFileReadWriteA
 			zipMessages(String.format("%s%s.%s", baseName, TRANSACTIONS_SUFFIX, ZIP_EXTENSION),
 					TRANSACTION_EXTENSION);
 			zipMessages(String.format("%s%s.%s", baseName, SIGNATURES_SUFFIX, ZIP_EXTENSION),
-					SIGNATURE_EXTENSION);
+					SIGNATURE_EXTENSION, JSON_EXTENSION);
 		}
 
 		private void summarizeTransactions(final String baseName) throws HederaClientException, IOException {
@@ -1189,9 +1190,9 @@ public class TransactionFile extends RemoteFile implements GenericFileReadWriteA
 			}
 		}
 
-		private void zipMessages(final String messages, final String ext) throws HederaClientException {
+		private void zipMessages(final String messages, final String... exts) throws HederaClientException {
 			try {
-				final var txToPack = new File(tempStorage).listFiles((dir, name) -> name.endsWith(ext));
+				final var txToPack = new File(tempStorage).listFiles((dir, name) -> Arrays.stream(exts).anyMatch(name::endsWith));
 				if (txToPack == null) {
 					throw new HederaClientRuntimeException("Unable to read list of transactions to pack");
 				}

--- a/tools-core/src/main/java/com/hedera/hashgraph/client/core/remote/helpers/DistributionMaker.java
+++ b/tools-core/src/main/java/com/hedera/hashgraph/client/core/remote/helpers/DistributionMaker.java
@@ -53,6 +53,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static com.hedera.hashgraph.client.core.constants.Constants.FILE_NAME_GROUP_SEPARATOR;
+import static com.hedera.hashgraph.client.core.constants.Constants.JSON_EXTENSION;
 import static com.hedera.hashgraph.client.core.constants.Constants.SIGNATURE_EXTENSION;
 import static com.hedera.hashgraph.client.core.constants.Constants.TRANSACTION_EXTENSION;
 import static com.hedera.hashgraph.client.core.constants.JsonConstants.ACCOUNT;
@@ -159,7 +160,7 @@ public class DistributionMaker implements GenericFileReadWriteAware {
 			throw new HederaClientException(e);
 		}
 		zipMessages(TRANSACTIONS_SUFFIX, TRANSACTION_EXTENSION);
-		zipMessages(SIGNATURES_SUFFIX, SIGNATURE_EXTENSION);
+		zipMessages(SIGNATURES_SUFFIX, SIGNATURE_EXTENSION, JSON_EXTENSION);
 	}
 
 	private ToolTransaction buildTransfer(final BatchLine distributionData) throws HederaClientException {
@@ -238,9 +239,9 @@ public class DistributionMaker implements GenericFileReadWriteAware {
 		}
 	}
 
-	private void zipMessages(final String messages, final String ext) throws HederaClientException {
+	private void zipMessages(final String messages, final String... exts) throws HederaClientException {
 		try {
-			final var txToPack = new File(storageLocation + messages).listFiles((dir, name) -> name.endsWith(ext));
+			final var txToPack = new File(storageLocation + messages).listFiles((dir, name) -> Arrays.stream(exts).anyMatch(name::endsWith));
 			if (txToPack == null) {
 				throw new HederaClientRuntimeException("Unable to read list of transactions to pack");
 			}

--- a/tools-core/src/main/java/com/hedera/hashgraph/client/core/transactions/SignaturePair.java
+++ b/tools-core/src/main/java/com/hedera/hashgraph/client/core/transactions/SignaturePair.java
@@ -18,6 +18,7 @@
 
 package com.hedera.hashgraph.client.core.transactions;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hedera.hashgraph.client.core.action.GenericFileReadWriteAware;
 import com.hedera.hashgraph.sdk.PublicKey;
 import org.apache.logging.log4j.LogManager;
@@ -33,6 +34,9 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.util.Arrays;
+
+import static com.hedera.hashgraph.client.core.constants.Constants.JSON_EXTENSION;
+import static com.hedera.hashgraph.client.core.constants.Constants.SIGNATURE_EXTENSION;
 
 public class SignaturePair implements GenericFileReadWriteAware, Serializable {
 	private static final Logger logger = LogManager.getLogger(SignaturePair.class);
@@ -66,14 +70,21 @@ public class SignaturePair implements GenericFileReadWriteAware, Serializable {
 		return signature;
 	}
 
-
 	public void write(final String filePath) {
 		try {
 
-			try (final var fileOut = new FileOutputStream(
-					filePath); final var objectOut = new ObjectOutputStream(fileOut)) {
+			try (final var fileOut = new FileOutputStream(filePath);
+				 final var objectOut = new ObjectOutputStream(fileOut)) {
 				objectOut.writeObject(this);
-				logger.info("The Object  was successfully written to a file");
+				logger.info("The Object was successfully written to a file");
+			}
+
+			// Write the JSON representation - for importing into TTv2
+			final String jsonFilePath = filePath.replace(SIGNATURE_EXTENSION, JSON_EXTENSION);
+			final var mapper = new ObjectMapper();
+			try (final var jsonOut = new FileOutputStream(jsonFilePath)) {
+				mapper.writeValue(jsonOut, this);
+				logger.info("The JSON was successfully written to a file");
 			}
 		} catch (final Exception ex) {
 			logger.error(ex);

--- a/tools-integration/pom.xml
+++ b/tools-integration/pom.xml
@@ -23,13 +23,13 @@
 	<parent>
 		<artifactId>hedera-transaction-tool</artifactId>
 		<groupId>com.hedera.hashgraph</groupId>
-		<version>0.14.7</version>
+		<version>0.14.8</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>tools-integration</artifactId>
-	<version>0.14.7</version>
+	<version>0.14.8</version>
 
 	<dependencyManagement>
 		<dependencies>
@@ -47,19 +47,19 @@
 		<dependency>
 			<groupId>com.hedera.hashgraph</groupId>
 			<artifactId>tools-core</artifactId>
-			<version>0.14.7</version>
+			<version>0.14.8</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.hedera.hashgraph</groupId>
 			<artifactId>tools-ui</artifactId>
-			<version>0.14.7</version>
+			<version>0.14.8</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.hedera.hashgraph</groupId>
 			<artifactId>tools-cli</artifactId>
-			<version>0.14.7</version>
+			<version>0.14.8</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/tools-ui/pom.xml
+++ b/tools-ui/pom.xml
@@ -26,7 +26,7 @@
 	<parent>
 		<artifactId>hedera-transaction-tool</artifactId>
 		<groupId>com.hedera.hashgraph</groupId>
-		<version>0.14.7</version>
+		<version>0.14.8</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -34,7 +34,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>tools-ui</artifactId>
-	<version>0.14.7</version>
+	<version>0.14.8</version>
 
 	<!-- Project Properties -->
 	<properties>
@@ -59,7 +59,7 @@
 		<dependency>
 			<groupId>com.hedera.hashgraph</groupId>
 			<artifactId>tools-core</artifactId>
-			<version>0.14.7</version>
+			<version>0.14.8</version>
 		</dependency>
 
 		<!-- SDK Dependency -->


### PR DESCRIPTION
**Description**:
TTv2 importing of signatures cannot import Java's 'standard' serialized object. A second output format is needed. Json will be used. These .json files will be packaged along with the .sig files.
