### PR TITLE
fix: multi sig flow for a multi node transaction

### DIFF
--- a/tools-core/src/main/java/com/hedera/hashgraph/client/core/mirrornode/dtos/KeyType.java
+++ b/tools-core/src/main/java/com/hedera/hashgraph/client/core/mirrornode/dtos/KeyType.java
@@ -29,7 +29,7 @@ public enum KeyType {
     public static KeyType fromString(String value) {
         if ("ED25519".equals(value)) {
             return ED25519;
-        } else if ("ECDSASecp256k1".equals(value)) {
+        } else if ("ECDSASecp256k1".equals(value) || "ECDSA_SECP256K1".equals(value)) {
             return ECDSA_SECP256K1;
         } else if ("ProtobufEncoded".equals(value)) {
             return PROTOBUF_ENCODED;

--- a/tools-core/src/main/java/com/hedera/hashgraph/client/core/remote/TransactionFile.java
+++ b/tools-core/src/main/java/com/hedera/hashgraph/client/core/remote/TransactionFile.java
@@ -1123,7 +1123,7 @@ public class TransactionFile extends RemoteFile implements GenericFileReadWriteA
 					Path.of(tempStorage, getBaseName() + "." + TRANSACTION_EXTENSION).toString());
 			String signatureFile;
 
-			final Transaction<?> tx = transaction.getTransaction();
+			final Transaction<?> tx = CommonMethods.getTransaction(transaction.getTransaction().toBytes());
 			if (Objects.requireNonNull(tx.getNodeAccountIds()).size() > 1) {
 				signatureFile = tempTxFile.replaceFirst(TRANSACTION_EXTENSION + "$", JSON_EXTENSION);
 
@@ -1160,7 +1160,7 @@ public class TransactionFile extends RemoteFile implements GenericFileReadWriteA
 				signaturePair.write(signatureFile);
 			}
 
-			final var toPack = new File[] { new File(tempTxFile), new File(signatureFile), new File(signatureFile.replace(SIGNATURE_EXTENSION, JSON_EXTENSION)) };
+			final var toPack = new File[] { new File(tempTxFile), new File(signatureFile) };
 
 			Arrays.stream(toPack).filter(file -> !file.exists() || !file.isFile()).forEach(file -> {
 				throw new HederaClientRuntimeException("Invalid file in file list");

--- a/tools-core/src/main/java/com/hedera/hashgraph/client/core/remote/TransactionFile.java
+++ b/tools-core/src/main/java/com/hedera/hashgraph/client/core/remote/TransactionFile.java
@@ -93,6 +93,7 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -1129,22 +1130,21 @@ public class TransactionFile extends RemoteFile implements GenericFileReadWriteA
 
 				// This map should only have one entry, due to TTv2 export. But just in case,
 				// we will handle it more generally
-				final Map<AccountId, Map<PublicKey, byte[]>> sigs = tx.getSignatures();
 				final Map<AccountId, Map<PublicKey, byte[]>> newSigs = tx.sign(privateKey).getSignatures();
 
-				for (Map.Entry<AccountId, Map<PublicKey, byte[]>> entry : sigs.entrySet()) {
-					AccountId accountId = entry.getKey();
+				// Pull all the sigs from newSigs that belong to this private key
+				final PublicKey publicKey = privateKey.getPublicKey();
+				// Only keep signatures in newSigs that match the given publicKey
+				for (Iterator<Map.Entry<AccountId, Map<PublicKey, byte[]>>> it = newSigs.entrySet().iterator(); it.hasNext(); ) {
+					Map.Entry<AccountId, Map<PublicKey, byte[]>> entry = it.next();
 					Map<PublicKey, byte[]> sigMap = entry.getValue();
 
-					if (newSigs.containsKey(accountId)) {
-						Map<PublicKey, byte[]> newSigMap = newSigs.get(accountId);
-						for (PublicKey publicKey : sigMap.keySet()) {
-							newSigMap.remove(publicKey);
-						}
-						// If the inner map is empty after removals, remove the outer key
-						if (newSigMap.isEmpty()) {
-							newSigs.remove(accountId);
-						}
+					// Remove all public keys that do not match the given publicKey
+					sigMap.keySet().removeIf(key -> !key.equals(publicKey));
+
+					// If the inner map is now empty, remove the outer entry
+					if (sigMap.isEmpty()) {
+						it.remove();
 					}
 				}
 


### PR DESCRIPTION
**Description**:
Using the new multi-node flow, when the transaction is imported from TTv2, the output of multi key signing was different than similar flows. While not incorrect, it was not consistent. Now, the output if this flow is consistent with all other TTv1 flows.